### PR TITLE
Weather Data, Offline Support, and Home Screen Integration 🔥❤

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,6 +2,8 @@ plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.kotlin.serialization)
+    alias(libs.plugins.ksp)
+
 }
 
 android {
@@ -18,6 +20,11 @@ android {
         versionName = "1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+
+        buildFeatures { buildConfig = true }
+
+        buildConfigField("String", "WEATHER_API_KEY",
+            "\"${properties["WEATHER_API_KEY"]}\"")
     }
 
     buildTypes {
@@ -65,7 +72,13 @@ dependencies {
     implementation(libs.coil.compose)
     implementation(libs.androidx.compose.material.icons.extended)
     implementation(libs.kotlinx.coroutines.play.services)
-
+    implementation(libs.retrofit)
+    implementation(libs.converter.gson)
+    implementation(libs.retrofit)
+    ksp(libs.room.compiler)
+    implementation(libs.room.runtime)
+    implementation(libs.room.ktx)
+    implementation(libs.okhttp.logging)
 
 
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,13 +1,23 @@
+import java.util.Properties
+
+val properties = Properties()
+val localPropertiesFile = rootProject.file("local.properties")
+
+if (localPropertiesFile.exists()) {
+    properties.load(localPropertiesFile.inputStream())
+}
+
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.ksp)
-
 }
 
 android {
+
     namespace = "com.iti.skypulse"
+
     compileSdk {
         version = release(36)
     }
@@ -23,25 +33,11 @@ android {
 
         buildFeatures { buildConfig = true }
 
-        buildConfigField("String", "WEATHER_API_KEY",
-            "\"${properties["WEATHER_API_KEY"]}\"")
-    }
-
-    buildTypes {
-        release {
-            isMinifyEnabled = false
-            proguardFiles(
-                getDefaultProguardFile("proguard-android-optimize.txt"),
-                "proguard-rules.pro"
-            )
-        }
-    }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
-    }
-    buildFeatures {
-        compose = true
+        buildConfigField(
+            "String",
+            "WEATHER_API_KEY",
+            "\"${properties["WEATHER_API_KEY"]}\""
+        )
     }
 }
 
@@ -79,6 +75,7 @@ dependencies {
     implementation(libs.room.runtime)
     implementation(libs.room.ktx)
     implementation(libs.okhttp.logging)
+    implementation(libs.shimmer)
 
 
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
 
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET"/>
     <application
         android:name=".SkyPulseApp"

--- a/app/src/main/java/com/iti/skypulse/MainActivity.kt
+++ b/app/src/main/java/com/iti/skypulse/MainActivity.kt
@@ -4,19 +4,32 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.activity.viewModels
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import com.iti.skypulse.ui.navigation.AppNavigation
+import com.iti.skypulse.ui.preferences.LocalPreferencesViewModel
+import com.iti.skypulse.ui.preferences.PreferencesViewModel
+import com.iti.skypulse.ui.preferences.PreferencesViewModelFactory
 import com.iti.skypulse.ui.theme.SkyPulseTheme
 
 class MainActivity : ComponentActivity() {
+    private val preferencesViewModel: PreferencesViewModel by viewModels {
+        PreferencesViewModelFactory()
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         installSplashScreen()
         enableEdgeToEdge()
 
         setContent {
-            SkyPulseTheme {
-                AppNavigation()
+            CompositionLocalProvider(
+                LocalPreferencesViewModel provides preferencesViewModel
+            ) {
+                SkyPulseTheme {
+                    AppNavigation()
+                }
             }
         }
     }

--- a/app/src/main/java/com/iti/skypulse/SkyPulseApp.kt
+++ b/app/src/main/java/com/iti/skypulse/SkyPulseApp.kt
@@ -2,10 +2,24 @@ package com.iti.skypulse
 
 import android.app.Application
 import com.iti.skypulse.di.ServiceLocator
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import java.util.Locale
 
 class SkyPulseApp : Application() {
     override fun onCreate() {
         super.onCreate()
         ServiceLocator.init(this)
+        applyLanguage()
+    }
+
+    private fun applyLanguage() {
+        val langCode = runBlocking { ServiceLocator.appPreferences.language.first() }
+        val locale = Locale.forLanguageTag(langCode)
+        Locale.setDefault(locale)
+
+        val config = resources.configuration
+        config.setLocale(locale)
+        createConfigurationContext(config)
     }
 }

--- a/app/src/main/java/com/iti/skypulse/core/error/AppException.kt
+++ b/app/src/main/java/com/iti/skypulse/core/error/AppException.kt
@@ -1,7 +1,19 @@
 package com.iti.skypulse.core.error
 
+import androidx.annotation.StringRes
+import com.iti.skypulse.R
+
 sealed class AppException : Exception() {
     class NoInternetException : AppException()
     class NoCacheException : AppException()
     class ApiException(val code: Int, override val message: String) : AppException()
+}
+
+@StringRes
+fun Throwable?.toMessageRes(): Int {
+    return when (this) {
+        is AppException.NoInternetException -> R.string.error_no_internet
+        is AppException.NoCacheException    -> R.string.error_no_cache
+        else                                -> R.string.error_generic
+    }
 }

--- a/app/src/main/java/com/iti/skypulse/core/error/AppException.kt
+++ b/app/src/main/java/com/iti/skypulse/core/error/AppException.kt
@@ -1,0 +1,7 @@
+package com.iti.skypulse.core.error
+
+sealed class AppException : Exception() {
+    class NoInternetException : AppException()
+    class NoCacheException : AppException()
+    class ApiException(val code: Int, override val message: String) : AppException()
+}

--- a/app/src/main/java/com/iti/skypulse/core/network/ConnectivityHelper.kt
+++ b/app/src/main/java/com/iti/skypulse/core/network/ConnectivityHelper.kt
@@ -1,0 +1,13 @@
+package com.iti.skypulse.core.network
+
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
+
+class ConnectivityHelper(private val connectivityManager: ConnectivityManager) {
+
+    fun isOnline(): Boolean {
+        val network = connectivityManager.activeNetwork ?: return false
+        val capabilities = connectivityManager.getNetworkCapabilities(network) ?: return false
+        return capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+    }
+}

--- a/app/src/main/java/com/iti/skypulse/core/utils/UnitConverter.kt
+++ b/app/src/main/java/com/iti/skypulse/core/utils/UnitConverter.kt
@@ -1,0 +1,70 @@
+package com.iti.skypulse.core.utils
+import androidx.annotation.StringRes
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import com.iti.skypulse.R
+
+data class ConvertedValue(
+    val value: String,
+    @param:StringRes val unitRes: Int
+) {
+
+    @Composable
+    fun display(): String {
+        return "$value ${stringResource(unitRes)}"
+    }
+}
+
+object UnitConverter {
+
+    fun formatTemp(kelvin: Double, unit: TempUnit): ConvertedValue {
+        val converted = when (unit) {
+            TempUnit.CELSIUS    -> kelvin - 273.15
+            TempUnit.FAHRENHEIT -> (kelvin - 273.15) * 9 / 5 + 32
+            TempUnit.KELVIN     -> kelvin
+        }
+        return ConvertedValue(
+            value = "%.1f".format(converted),
+            unitRes = when (unit) {
+                TempUnit.CELSIUS    -> R.string.unit_celsius
+                TempUnit.FAHRENHEIT -> R.string.unit_fahrenheit
+                TempUnit.KELVIN     -> R.string.unit_kelvin
+            }
+        )
+    }
+
+    fun formatWind(metersPerSecond: Double, unit: WindUnit): ConvertedValue {
+        val converted = when (unit) {
+            WindUnit.METERS_PER_SECOND   -> metersPerSecond
+            WindUnit.KILOMETERS_PER_HOUR -> metersPerSecond * 3.6
+            WindUnit.MILES_PER_HOUR      -> metersPerSecond * 2.237
+        }
+        return ConvertedValue(
+            value = "%.1f".format(converted),
+            unitRes = when (unit) {
+                WindUnit.METERS_PER_SECOND   -> R.string.unit_ms
+                WindUnit.KILOMETERS_PER_HOUR -> R.string.unit_kmh
+                WindUnit.MILES_PER_HOUR      -> R.string.unit_mph
+            }
+        )
+    }
+
+    fun formatPressure(hpa: Int, unit: PressureUnit): ConvertedValue {
+        val converted = when (unit) {
+            PressureUnit.HPA  -> hpa.toDouble()
+            PressureUnit.MBAR -> hpa.toDouble()
+            PressureUnit.MMHG -> hpa * 0.750062
+        }
+        return ConvertedValue(
+            value = when (unit) {
+                PressureUnit.MMHG -> "%.1f".format(converted)
+                else              -> "%d".format(converted.toInt())
+            },
+            unitRes = when (unit) {
+                PressureUnit.HPA  -> R.string.unit_hpa
+                PressureUnit.MBAR -> R.string.unit_mbar
+                PressureUnit.MMHG -> R.string.unit_mmhg
+            }
+        )
+    }
+}

--- a/app/src/main/java/com/iti/skypulse/core/utils/Units.kt
+++ b/app/src/main/java/com/iti/skypulse/core/utils/Units.kt
@@ -1,0 +1,7 @@
+package com.iti.skypulse.core.utils
+
+enum class TempUnit { CELSIUS, FAHRENHEIT, KELVIN }
+
+enum class WindUnit { METERS_PER_SECOND, KILOMETERS_PER_HOUR, MILES_PER_HOUR }
+
+enum class PressureUnit { HPA, MBAR, MMHG }

--- a/app/src/main/java/com/iti/skypulse/data/local/datasource/WeatherLocalDataSource.kt
+++ b/app/src/main/java/com/iti/skypulse/data/local/datasource/WeatherLocalDataSource.kt
@@ -1,0 +1,11 @@
+package com.iti.skypulse.data.local.datasource
+
+import com.iti.skypulse.data.local.room.entity.ForecastEntity
+import com.iti.skypulse.data.local.room.entity.WeatherEntity
+
+interface WeatherLocalDataSource {
+    suspend fun getWeather(cityName: String): WeatherEntity?
+    suspend fun saveWeather(weather: WeatherEntity)
+    suspend fun getForecast(cityName: String): ForecastEntity?
+    suspend fun saveForecast(forecast: ForecastEntity)
+}

--- a/app/src/main/java/com/iti/skypulse/data/local/datasource/WeatherLocalDataSourceImpl.kt
+++ b/app/src/main/java/com/iti/skypulse/data/local/datasource/WeatherLocalDataSourceImpl.kt
@@ -1,0 +1,26 @@
+package com.iti.skypulse.data.local.datasource
+
+import com.iti.skypulse.data.local.room.dao.WeatherDao
+import com.iti.skypulse.data.local.room.entity.ForecastEntity
+import com.iti.skypulse.data.local.room.entity.WeatherEntity
+
+class WeatherLocalDataSourceImpl(
+    private val weatherDao: WeatherDao
+) : WeatherLocalDataSource {
+
+    override suspend fun getWeather(cityName: String): WeatherEntity? {
+        return weatherDao.getWeather(cityName)
+    }
+
+    override suspend fun saveWeather(weather: WeatherEntity) {
+        weatherDao.saveWeather(weather)
+    }
+
+    override suspend fun getForecast(cityName: String): ForecastEntity? {
+        return weatherDao.getForecast(cityName)
+    }
+
+    override suspend fun saveForecast(forecast: ForecastEntity) {
+        weatherDao.saveForecast(forecast)
+    }
+}

--- a/app/src/main/java/com/iti/skypulse/data/local/prefs/AppPreferences.kt
+++ b/app/src/main/java/com/iti/skypulse/data/local/prefs/AppPreferences.kt
@@ -21,7 +21,9 @@ class AppPreferences(private val context: Context) {
         private val LOCATION_LAT_KEY = doublePreferencesKey("location_lat")
         private val LOCATION_LNG_KEY = doublePreferencesKey("location_lng")
         private val LOCATION_PROVIDER_KEY = stringPreferencesKey("location_provider")
-
+        private val LANGUAGE_KEY = stringPreferencesKey("language")
+        const val LANG_ENGLISH = "en"
+        const val LANG_ARABIC = "ar"
     }
 
     val isOnboardingCompleted: Flow<Boolean> = context.dataStore.data
@@ -48,5 +50,14 @@ class AppPreferences(private val context: Context) {
         val provider = prefs[LOCATION_PROVIDER_KEY]
             ?.let { runCatching { LocationProvider.valueOf(it) }.getOrNull() }
         return if (lat != null && lng != null && provider != null) SavedLocation(lat, lng, provider) else null
+    }
+
+    val language: Flow<String> = context.dataStore.data
+        .map { prefs -> prefs[LANGUAGE_KEY] ?: LANG_ENGLISH }
+
+    suspend fun saveLanguage(langCode: String) {
+        context.dataStore.edit { prefs ->
+            prefs[LANGUAGE_KEY] = langCode
+        }
     }
 }

--- a/app/src/main/java/com/iti/skypulse/data/local/prefs/AppPreferences.kt
+++ b/app/src/main/java/com/iti/skypulse/data/local/prefs/AppPreferences.kt
@@ -6,6 +6,9 @@ import androidx.datastore.preferences.core.doublePreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
+import com.iti.skypulse.core.utils.PressureUnit
+import com.iti.skypulse.core.utils.TempUnit
+import com.iti.skypulse.core.utils.WindUnit
 import com.iti.skypulse.data.model.LocationProvider
 import com.iti.skypulse.data.model.SavedLocation
 import kotlinx.coroutines.flow.Flow
@@ -22,6 +25,9 @@ class AppPreferences(private val context: Context) {
         private val LOCATION_LNG_KEY = doublePreferencesKey("location_lng")
         private val LOCATION_PROVIDER_KEY = stringPreferencesKey("location_provider")
         private val LANGUAGE_KEY = stringPreferencesKey("language")
+        private val TEMP_UNIT_KEY = stringPreferencesKey("temp_unit")
+        private val WIND_UNIT_KEY = stringPreferencesKey("wind_unit")
+        private val PRESSURE_UNIT_KEY = stringPreferencesKey("pressure_unit")
         const val LANG_ENGLISH = "en"
         const val LANG_ARABIC = "ar"
     }
@@ -60,4 +66,44 @@ class AppPreferences(private val context: Context) {
             prefs[LANGUAGE_KEY] = langCode
         }
     }
+
+    val tempUnit: Flow<TempUnit> = context.dataStore.data
+        .map { prefs ->
+            prefs[TEMP_UNIT_KEY]
+                ?.let { runCatching { TempUnit.valueOf(it) }.getOrNull() }
+                ?: TempUnit.CELSIUS
+        }
+
+    suspend fun saveTempUnit(unit: TempUnit) {
+        context.dataStore.edit { prefs ->
+            prefs[TEMP_UNIT_KEY] = unit.name
+        }
+    }
+
+    val windUnit: Flow<WindUnit> = context.dataStore.data
+        .map { prefs ->
+            prefs[WIND_UNIT_KEY]
+                ?.let { runCatching { WindUnit.valueOf(it) }.getOrNull() }
+                ?: WindUnit.METERS_PER_SECOND
+        }
+
+    suspend fun saveWindUnit(unit: WindUnit) {
+        context.dataStore.edit { prefs ->
+            prefs[WIND_UNIT_KEY] = unit.name
+        }
+    }
+
+    val pressureUnit: Flow<PressureUnit> = context.dataStore.data
+        .map { prefs ->
+            prefs[PRESSURE_UNIT_KEY]
+                ?.let { runCatching { PressureUnit.valueOf(it) }.getOrNull() }
+                ?: PressureUnit.HPA
+        }
+
+    suspend fun savePressureUnit(unit: PressureUnit) {
+        context.dataStore.edit { prefs ->
+            prefs[PRESSURE_UNIT_KEY] = unit.name
+        }
+    }
+
 }

--- a/app/src/main/java/com/iti/skypulse/data/local/room/AppDatabase.kt
+++ b/app/src/main/java/com/iti/skypulse/data/local/room/AppDatabase.kt
@@ -1,0 +1,39 @@
+package com.iti.skypulse.data.local.room
+
+import androidx.room.Database
+import androidx.room.Room
+import androidx.room.RoomDatabase
+import androidx.room.TypeConverters
+import android.content.Context
+import com.iti.skypulse.data.local.room.converter.ForecastTypeConverter
+import com.iti.skypulse.data.local.room.dao.WeatherDao
+import com.iti.skypulse.data.local.room.entity.ForecastEntity
+import com.iti.skypulse.data.local.room.entity.WeatherEntity
+
+@Database(
+    entities = [WeatherEntity::class, ForecastEntity::class],
+    version = 1,
+    exportSchema = false
+)
+@TypeConverters(ForecastTypeConverter::class)
+abstract class AppDatabase : RoomDatabase() {
+
+    abstract fun weatherDao(): WeatherDao
+
+    companion object {
+        private const val DATABASE_NAME = "skypulse_db"
+
+        @Volatile
+        private var instance: AppDatabase? = null
+
+        fun getInstance(context: Context): AppDatabase {
+            return instance ?: synchronized(this) {
+                instance ?: Room.databaseBuilder(
+                    context.applicationContext,
+                    AppDatabase::class.java,
+                    DATABASE_NAME
+                ).build().also { instance = it }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/iti/skypulse/data/local/room/converter/ForecastTypeConverter.kt
+++ b/app/src/main/java/com/iti/skypulse/data/local/room/converter/ForecastTypeConverter.kt
@@ -1,0 +1,24 @@
+package com.iti.skypulse.data.local.room.converter
+
+import androidx.room.TypeConverter
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+import com.iti.skypulse.data.model.DailyForecastModel
+
+class ForecastTypeConverter {
+
+    private val gson = Gson()
+
+    @TypeConverter
+    fun fromDailyForecastList(value: List<DailyForecastModel>): String {
+        return gson.toJson(value)
+    }
+
+    @TypeConverter
+    fun toDailyForecastList(value: String): List<DailyForecastModel> {
+        return gson.fromJson(
+            value,
+            object : TypeToken<List<DailyForecastModel>>() {}.type
+        )
+    }
+}

--- a/app/src/main/java/com/iti/skypulse/data/local/room/dao/WeatherDao.kt
+++ b/app/src/main/java/com/iti/skypulse/data/local/room/dao/WeatherDao.kt
@@ -1,0 +1,29 @@
+package com.iti.skypulse.data.local.room.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.iti.skypulse.data.local.room.entity.ForecastEntity
+import com.iti.skypulse.data.local.room.entity.WeatherEntity
+
+@Dao
+interface WeatherDao {
+    @Query("SELECT * FROM weather WHERE cityName = :cityName")
+    suspend fun getWeather(cityName: String): WeatherEntity?
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun saveWeather(weather: WeatherEntity)
+
+    @Query("DELETE FROM weather WHERE cityName = :cityName")
+    suspend fun deleteWeather(cityName: String)
+
+    @Query("SELECT * FROM forecast WHERE cityName = :cityName")
+    suspend fun getForecast(cityName: String): ForecastEntity?
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun saveForecast(forecast: ForecastEntity)
+
+    @Query("DELETE FROM forecast WHERE cityName = :cityName")
+    suspend fun deleteForecast(cityName: String)
+}

--- a/app/src/main/java/com/iti/skypulse/data/local/room/dao/WeatherDao.kt
+++ b/app/src/main/java/com/iti/skypulse/data/local/room/dao/WeatherDao.kt
@@ -9,21 +9,21 @@ import com.iti.skypulse.data.local.room.entity.WeatherEntity
 
 @Dao
 interface WeatherDao {
-    @Query("SELECT * FROM weather WHERE cityName = :cityName")
-    suspend fun getWeather(cityName: String): WeatherEntity?
+    @Query("SELECT * FROM weather WHERE cacheKey = :cacheKey")
+    suspend fun getWeather(cacheKey: String): WeatherEntity?
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun saveWeather(weather: WeatherEntity)
 
-    @Query("DELETE FROM weather WHERE cityName = :cityName")
-    suspend fun deleteWeather(cityName: String)
+    @Query("DELETE FROM weather WHERE cacheKey = :cacheKey")
+    suspend fun deleteWeather(cacheKey: String)
 
-    @Query("SELECT * FROM forecast WHERE cityName = :cityName")
-    suspend fun getForecast(cityName: String): ForecastEntity?
+    @Query("SELECT * FROM forecast WHERE cacheKey = :cacheKey")
+    suspend fun getForecast(cacheKey: String): ForecastEntity?
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun saveForecast(forecast: ForecastEntity)
 
-    @Query("DELETE FROM forecast WHERE cityName = :cityName")
-    suspend fun deleteForecast(cityName: String)
+    @Query("DELETE FROM forecast WHERE cacheKey = :cacheKey")
+    suspend fun deleteForecast(cacheKey: String)
 }

--- a/app/src/main/java/com/iti/skypulse/data/local/room/entity/ForecastEntity.kt
+++ b/app/src/main/java/com/iti/skypulse/data/local/room/entity/ForecastEntity.kt
@@ -1,0 +1,15 @@
+package com.iti.skypulse.data.local.room.entity
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import com.iti.skypulse.data.model.DailyForecastModel
+
+@Entity(tableName = "forecast")
+data class ForecastEntity(
+    @PrimaryKey
+    val cacheKey: String,
+    val cityName: String,
+    val countryCode: String,
+    val dailyForecasts: List<DailyForecastModel>,
+    val lastUpdated: Long = System.currentTimeMillis()
+)

--- a/app/src/main/java/com/iti/skypulse/data/local/room/entity/WeatherEntity.kt
+++ b/app/src/main/java/com/iti/skypulse/data/local/room/entity/WeatherEntity.kt
@@ -1,0 +1,24 @@
+package com.iti.skypulse.data.local.room.entity
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "weather")
+data class WeatherEntity(
+    @PrimaryKey
+    val cacheKey: String,
+    val cityName: String,
+    val countryCode: String,
+    val temperature: Double,
+    val feelsLikeTemperature: Double,
+    val minimumTemperature: Double,
+    val maximumTemperature: Double,
+    val weatherDescription: String,
+    val weatherIconCode: String,
+    val windSpeed: Double,
+    val windDirectionDegrees: Int,
+    val humidityPercentage: Int,
+    val visibilityInMeters: Int,
+    val atmosphericPressure: Int,
+    val lastUpdated: Long = System.currentTimeMillis()
+)

--- a/app/src/main/java/com/iti/skypulse/data/model/ForecastModel.kt
+++ b/app/src/main/java/com/iti/skypulse/data/model/ForecastModel.kt
@@ -1,0 +1,24 @@
+package com.iti.skypulse.data.model
+
+data class ForecastModel(
+    val cityName: String,
+    val countryCode: String,
+    val dailyForecasts: List<DailyForecastModel>
+)
+
+data class DailyForecastModel(
+    val dayName: String,
+    val date: String,
+    val highTemperature: Double,
+    val lowTemperature: Double,
+    val weatherDescription: String,
+    val weatherIconCode: String,
+
+    val hourlyForecasts: List<HourlyForecastModel>
+)
+
+data class HourlyForecastModel(
+    val time: String,
+    val weatherIconCode: String,
+    val temperature: Double
+)

--- a/app/src/main/java/com/iti/skypulse/data/model/WeatherModel.kt
+++ b/app/src/main/java/com/iti/skypulse/data/model/WeatherModel.kt
@@ -1,0 +1,19 @@
+package com.iti.skypulse.data.model
+
+data class WeatherModel(
+    val temperature: Double,
+    val feelsLikeTemperature: Double,
+    val minimumTemperature: Double,
+    val maximumTemperature: Double,
+    val weatherDescription: String,
+    val weatherIconCode: String,
+
+    val windSpeed: Double,
+    val windDirectionDegrees: Int,
+    val humidityPercentage: Int,
+    val visibilityInMeters: Int,
+    val atmosphericPressure: Int,
+
+    val cityName: String,
+    val countryCode: String,
+)

--- a/app/src/main/java/com/iti/skypulse/data/model/mapper/WeatherMapper.kt
+++ b/app/src/main/java/com/iti/skypulse/data/model/mapper/WeatherMapper.kt
@@ -1,5 +1,7 @@
 package com.iti.skypulse.data.model.mapper
 
+import com.iti.skypulse.data.local.room.entity.ForecastEntity
+import com.iti.skypulse.data.local.room.entity.WeatherEntity
 import com.iti.skypulse.data.model.DailyForecastModel
 import com.iti.skypulse.data.model.ForecastModel
 import com.iti.skypulse.data.model.HourlyForecastModel
@@ -50,6 +52,54 @@ fun ForecastResponseDto.toForecastModel(): ForecastModel {
     )
 }
 
+fun WeatherModel.toWeatherEntity(cacheKey: String) = WeatherEntity(
+    cacheKey = cacheKey,
+    cityName = cityName,
+    countryCode = countryCode,
+    temperature = temperature,
+    feelsLikeTemperature = feelsLikeTemperature,
+    minimumTemperature = minimumTemperature,
+    maximumTemperature = maximumTemperature,
+    weatherDescription = weatherDescription,
+    weatherIconCode = weatherIconCode,
+    windSpeed = windSpeed,
+    windDirectionDegrees = windDirectionDegrees,
+    humidityPercentage = humidityPercentage,
+    visibilityInMeters = visibilityInMeters,
+    atmosphericPressure = atmosphericPressure,
+    lastUpdated = System.currentTimeMillis()
+)
+
+fun WeatherEntity.toWeatherModel() = WeatherModel(
+    cityName = cityName,
+    countryCode = countryCode,
+    temperature = temperature,
+    feelsLikeTemperature = feelsLikeTemperature,
+    minimumTemperature = minimumTemperature,
+    maximumTemperature = maximumTemperature,
+    weatherDescription = weatherDescription,
+    weatherIconCode = weatherIconCode,
+    windSpeed = windSpeed,
+    windDirectionDegrees = windDirectionDegrees,
+    humidityPercentage = humidityPercentage,
+    visibilityInMeters = visibilityInMeters,
+    atmosphericPressure = atmosphericPressure
+)
+
+fun ForecastModel.toForecastEntity(cacheKey: String) = ForecastEntity(
+    cacheKey = cacheKey,
+    cityName = cityName,
+    countryCode = countryCode,
+    dailyForecasts = dailyForecasts,
+    lastUpdated = System.currentTimeMillis()
+)
+
+fun ForecastEntity.toForecastModel() = ForecastModel(
+    cityName = cityName,
+    countryCode = countryCode,
+    dailyForecasts = dailyForecasts
+)
+
 private fun ForecastItemDto.toHourlyForecastModel() = HourlyForecastModel(
     time = dateTimeText.substring(11, 16),
     weatherIconCode = weatherConditions.firstOrNull()?.iconCode ?: "",
@@ -60,16 +110,12 @@ private fun String.toDayName(): String {
     return try {
         val date = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault()).parse(this)
         SimpleDateFormat("EEEE", Locale.getDefault()).format(date ?: Date())
-    } catch (e: Exception) {
-        this
-    }
+    } catch (_: Exception) { this }
 }
 
 private fun String.toFormattedDate(): String {
     return try {
         val date = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault()).parse(this)
         SimpleDateFormat("MMM dd", Locale.getDefault()).format(date ?: Date())
-    } catch (e: Exception) {
-        this
-    }
+    } catch (_: Exception) { this }
 }

--- a/app/src/main/java/com/iti/skypulse/data/model/mapper/WeatherMapper.kt
+++ b/app/src/main/java/com/iti/skypulse/data/model/mapper/WeatherMapper.kt
@@ -1,0 +1,75 @@
+package com.iti.skypulse.data.model.mapper
+
+import com.iti.skypulse.data.model.DailyForecastModel
+import com.iti.skypulse.data.model.ForecastModel
+import com.iti.skypulse.data.model.HourlyForecastModel
+import com.iti.skypulse.data.model.WeatherModel
+import com.iti.skypulse.data.remote.dto.ForecastItemDto
+import com.iti.skypulse.data.remote.dto.ForecastResponseDto
+import com.iti.skypulse.data.remote.dto.WeatherResponseDto
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+fun WeatherResponseDto.toWeatherModel() = WeatherModel(
+    temperature = mainMetrics.temperature,
+    feelsLikeTemperature = mainMetrics.feelsLikeTemperature,
+    minimumTemperature = mainMetrics.minimumTemperature,
+    maximumTemperature = mainMetrics.maximumTemperature,
+    weatherDescription = weatherConditions.firstOrNull()?.conditionDescription ?: "",
+    weatherIconCode = weatherConditions.firstOrNull()?.iconCode ?: "",
+    windSpeed = wind.speedInMetersPerSecond,
+    windDirectionDegrees = wind.directionInDegrees,
+    humidityPercentage = mainMetrics.humidityPercentage,
+    visibilityInMeters = visibilityInMeters,
+    atmosphericPressure = mainMetrics.atmosphericPressure,
+    cityName = cityName,
+    countryCode = systemInfo.countryCode
+)
+
+fun ForecastResponseDto.toForecastModel(): ForecastModel {
+    val dailyGroups = forecastItems
+        .groupBy { it.dateTimeText.substring(0, 10) }
+
+    val dailyForecasts = dailyGroups.map { (date, items) ->
+        DailyForecastModel(
+            dayName = date.toDayName(),
+            date = date.toFormattedDate(),
+            highTemperature = items.maxOf { it.mainMetrics.maximumTemperature },
+            lowTemperature = items.minOf { it.mainMetrics.minimumTemperature },
+            weatherDescription = items.first().weatherConditions.firstOrNull()?.conditionDescription ?: "",
+            weatherIconCode = items.first().weatherConditions.firstOrNull()?.iconCode ?: "",
+            hourlyForecasts = items.map { it.toHourlyForecastModel() }
+        )
+    }
+
+    return ForecastModel(
+        cityName = city.cityName,
+        countryCode = city.countryCode,
+        dailyForecasts = dailyForecasts
+    )
+}
+
+private fun ForecastItemDto.toHourlyForecastModel() = HourlyForecastModel(
+    time = dateTimeText.substring(11, 16),
+    weatherIconCode = weatherConditions.firstOrNull()?.iconCode ?: "",
+    temperature = mainMetrics.temperature
+)
+
+private fun String.toDayName(): String {
+    return try {
+        val date = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault()).parse(this)
+        SimpleDateFormat("EEEE", Locale.getDefault()).format(date ?: Date())
+    } catch (e: Exception) {
+        this
+    }
+}
+
+private fun String.toFormattedDate(): String {
+    return try {
+        val date = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault()).parse(this)
+        SimpleDateFormat("MMM dd", Locale.getDefault()).format(date ?: Date())
+    } catch (e: Exception) {
+        this
+    }
+}

--- a/app/src/main/java/com/iti/skypulse/data/remote/api/ApiClient.kt
+++ b/app/src/main/java/com/iti/skypulse/data/remote/api/ApiClient.kt
@@ -1,0 +1,63 @@
+package com.iti.skypulse.data.remote.api
+
+import com.iti.skypulse.BuildConfig
+import okhttp3.Interceptor
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+import java.util.concurrent.TimeUnit
+
+object ApiClient {
+
+    private const val BASE_URL = "https://api.openweathermap.org/data/2.5/"
+    private const val API_KEY_FIELD = "appid"
+    private const val LANGUAGE_FIELD = "lang"
+
+    @Volatile
+    private var instance: Retrofit? = null
+
+    private var language: String? = null
+
+    private val apiKeyInterceptor = Interceptor { chain ->
+        val newUrl = chain.request().url.newBuilder()
+            .addQueryParameter(LANGUAGE_FIELD, language)
+            .addQueryParameter(API_KEY_FIELD, BuildConfig.WEATHER_API_KEY)
+            .build()
+        chain.proceed(chain.request().newBuilder().url(newUrl).build())
+    }
+
+    fun init(language: String) {
+        synchronized(this) {
+            this.language = language
+        }
+    }
+
+    private val loggingInterceptor = HttpLoggingInterceptor().apply {
+        level = HttpLoggingInterceptor.Level.BODY
+    }
+
+    private val okHttpClient = OkHttpClient.Builder()
+        .addInterceptor(apiKeyInterceptor)
+        .addInterceptor(loggingInterceptor)
+        .connectTimeout(30, TimeUnit.SECONDS)
+        .readTimeout(30, TimeUnit.SECONDS)
+        .build()
+
+    fun getInstance(): Retrofit {
+
+        return instance ?: synchronized(this) {
+            instance ?: run {
+                checkNotNull(language) {
+                    "ApiClient not initialized. Call ApiClient.init() before using getInstance()"
+                }
+                Retrofit.Builder()
+                    .baseUrl(BASE_URL)
+                    .client(okHttpClient)
+                    .addConverterFactory(GsonConverterFactory.create())
+                    .build()
+                    .also { instance = it }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/iti/skypulse/data/remote/api/ApiClient.kt
+++ b/app/src/main/java/com/iti/skypulse/data/remote/api/ApiClient.kt
@@ -19,7 +19,7 @@ object ApiClient {
 
     private var language: String? = null
 
-    private val apiKeyInterceptor = Interceptor { chain ->
+    private val queryParamsInterceptor = Interceptor { chain ->
         val newUrl = chain.request().url.newBuilder()
             .addQueryParameter(LANGUAGE_FIELD, language)
             .addQueryParameter(API_KEY_FIELD, BuildConfig.WEATHER_API_KEY)
@@ -38,7 +38,7 @@ object ApiClient {
     }
 
     private val okHttpClient = OkHttpClient.Builder()
-        .addInterceptor(apiKeyInterceptor)
+        .addInterceptor(queryParamsInterceptor)
         .addInterceptor(loggingInterceptor)
         .connectTimeout(30, TimeUnit.SECONDS)
         .readTimeout(30, TimeUnit.SECONDS)

--- a/app/src/main/java/com/iti/skypulse/data/remote/api/WeatherApiService.kt
+++ b/app/src/main/java/com/iti/skypulse/data/remote/api/WeatherApiService.kt
@@ -1,0 +1,21 @@
+package com.iti.skypulse.data.remote.api
+
+import com.iti.skypulse.data.remote.dto.ForecastResponseDto
+import com.iti.skypulse.data.remote.dto.WeatherResponseDto
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+interface WeatherApiService {
+
+    @GET("weather")
+    suspend fun getCurrentWeather(
+        @Query("lat") latitude: Double,
+        @Query("lon") longitude: Double,
+    ): WeatherResponseDto
+
+    @GET("forecast")
+    suspend fun getFiveDayForecast(
+        @Query("lat") latitude: Double,
+        @Query("lon") longitude: Double,
+    ): ForecastResponseDto
+}

--- a/app/src/main/java/com/iti/skypulse/data/remote/datasource/WeatherRemoteDataSource.kt
+++ b/app/src/main/java/com/iti/skypulse/data/remote/datasource/WeatherRemoteDataSource.kt
@@ -1,0 +1,9 @@
+package com.iti.skypulse.data.remote.datasource
+
+import com.iti.skypulse.data.remote.dto.ForecastResponseDto
+import com.iti.skypulse.data.remote.dto.WeatherResponseDto
+
+interface WeatherRemoteDataSource {
+    suspend fun getCurrentWeather(latitude: Double, longitude: Double): WeatherResponseDto
+    suspend fun getFiveDayForecast(latitude: Double, longitude: Double): ForecastResponseDto
+}

--- a/app/src/main/java/com/iti/skypulse/data/remote/datasource/WeatherRemoteDataSourceImpl.kt
+++ b/app/src/main/java/com/iti/skypulse/data/remote/datasource/WeatherRemoteDataSourceImpl.kt
@@ -1,0 +1,23 @@
+package com.iti.skypulse.data.remote.datasource
+
+import com.iti.skypulse.data.remote.api.WeatherApiService
+import com.iti.skypulse.data.remote.dto.ForecastResponseDto
+import com.iti.skypulse.data.remote.dto.WeatherResponseDto
+
+class WeatherRemoteDataSourceImpl
+    (private val weatherApiService: WeatherApiService) : WeatherRemoteDataSource {
+
+    override suspend fun getCurrentWeather(
+        latitude: Double,
+        longitude: Double
+    ): WeatherResponseDto {
+        return weatherApiService.getCurrentWeather(latitude, longitude)
+    }
+
+    override suspend fun getFiveDayForecast(
+        latitude: Double,
+        longitude: Double
+    ): ForecastResponseDto {
+        return weatherApiService.getFiveDayForecast(latitude, longitude)
+    }
+}

--- a/app/src/main/java/com/iti/skypulse/data/remote/dto/CommonDtos.kt
+++ b/app/src/main/java/com/iti/skypulse/data/remote/dto/CommonDtos.kt
@@ -1,0 +1,28 @@
+package com.iti.skypulse.data.remote.dto
+
+import com.google.gson.annotations.SerializedName
+
+data class CoordinatesDto(
+    @SerializedName("lon") val longitude: Double,
+    @SerializedName("lat") val latitude: Double
+)
+
+data class WeatherConditionDto(
+    @SerializedName("id") val conditionId: Int,
+    @SerializedName("main") val conditionGroup: String,
+    @SerializedName("description") val conditionDescription: String,
+    @SerializedName("icon") val iconCode: String
+)
+
+data class MainMetricsDto(
+    @SerializedName("temp") val temperature: Double,
+    @SerializedName("feels_like") val feelsLikeTemperature: Double,
+    @SerializedName("temp_min") val minimumTemperature: Double,
+    @SerializedName("temp_max") val maximumTemperature: Double,
+    @SerializedName("pressure") val atmosphericPressure: Int,
+    @SerializedName("humidity") val humidityPercentage: Int
+)
+
+data class CloudsDto(
+    @SerializedName("all") val cloudinessPercentage: Int
+)

--- a/app/src/main/java/com/iti/skypulse/data/remote/dto/ForecastResponseDto.kt
+++ b/app/src/main/java/com/iti/skypulse/data/remote/dto/ForecastResponseDto.kt
@@ -1,0 +1,44 @@
+package com.iti.skypulse.data.remote.dto
+
+import com.google.gson.annotations.SerializedName
+
+data class ForecastResponseDto(
+    @SerializedName("cod") val responseCode: String,
+    @SerializedName("message") val message: Int,
+    @SerializedName("cnt") val itemCount: Int,
+    @SerializedName("list") val forecastItems: List<ForecastItemDto>,
+    @SerializedName("city") val city: ForecastCityDto
+)
+
+data class ForecastItemDto(
+    @SerializedName("dt") val dataCalculatedAt: Long,
+    @SerializedName("main") val mainMetrics: MainMetricsDto,
+    @SerializedName("weather") val weatherConditions: List<WeatherConditionDto>,
+    @SerializedName("clouds") val clouds: CloudsDto,
+    @SerializedName("wind") val wind: ForecastWindDto,
+    @SerializedName("visibility") val visibilityInMeters: Int,
+    @SerializedName("pop") val precipitationProbability: Double,
+    @SerializedName("sys") val partOfDay: PartOfDayDto,
+    @SerializedName("dt_txt") val dateTimeText: String
+)
+
+data class ForecastWindDto(
+    @SerializedName("speed") val speedInMetersPerSecond: Double,
+    @SerializedName("deg") val directionInDegrees: Int,
+    @SerializedName("gust") val gustSpeedInMetersPerSecond: Double
+)
+
+data class PartOfDayDto(
+    @SerializedName("pod") val partOfDay: String
+)
+
+data class ForecastCityDto(
+    @SerializedName("id") val cityId: Int,
+    @SerializedName("name") val cityName: String,
+    @SerializedName("coord") val coordinates: CoordinatesDto,
+    @SerializedName("country") val countryCode: String,
+    @SerializedName("population") val population: Int,
+    @SerializedName("timezone") val timezoneOffsetInSeconds: Int,
+    @SerializedName("sunrise") val sunriseTimestamp: Long,
+    @SerializedName("sunset") val sunsetTimestamp: Long
+)

--- a/app/src/main/java/com/iti/skypulse/data/remote/dto/WeatherResponseDto.kt
+++ b/app/src/main/java/com/iti/skypulse/data/remote/dto/WeatherResponseDto.kt
@@ -1,0 +1,30 @@
+package com.iti.skypulse.data.remote.dto
+
+import com.google.gson.annotations.SerializedName
+
+data class WeatherResponseDto(
+    @SerializedName("coord") val coordinates: CoordinatesDto,
+    @SerializedName("weather") val weatherConditions: List<WeatherConditionDto>,
+    @SerializedName("main") val mainMetrics: MainMetricsDto,
+    @SerializedName("visibility") val visibilityInMeters: Int,
+    @SerializedName("wind") val wind: WindDto,
+    @SerializedName("clouds") val clouds: CloudsDto,
+    @SerializedName("dt") val dataCalculatedAt: Long,
+    @SerializedName("sys") val systemInfo: SystemInfoDto,
+    @SerializedName("timezone") val timezoneOffsetInSeconds: Int,
+    @SerializedName("id") val cityId: Int,
+    @SerializedName("name") val cityName: String,
+    @SerializedName("cod") val responseCode: Int
+)
+
+
+data class WindDto(
+    @SerializedName("speed") val speedInMetersPerSecond: Double,
+    @SerializedName("deg") val directionInDegrees: Int
+)
+
+data class SystemInfoDto(
+    @SerializedName("country") val countryCode: String,
+    @SerializedName("sunrise") val sunriseTimestamp: Long,
+    @SerializedName("sunset") val sunsetTimestamp: Long
+)

--- a/app/src/main/java/com/iti/skypulse/data/repository/WeatherRepository.kt
+++ b/app/src/main/java/com/iti/skypulse/data/repository/WeatherRepository.kt
@@ -1,0 +1,9 @@
+package com.iti.skypulse.data.repository
+
+import com.iti.skypulse.data.model.ForecastModel
+import com.iti.skypulse.data.model.WeatherModel
+
+interface WeatherRepository {
+    suspend fun getCurrentWeather(latitude: Double, longitude: Double): Result<WeatherModel>
+    suspend fun getFiveDayForecast(latitude: Double, longitude: Double): Result<ForecastModel>
+}

--- a/app/src/main/java/com/iti/skypulse/data/repository/WeatherRepositoryImpl.kt
+++ b/app/src/main/java/com/iti/skypulse/data/repository/WeatherRepositoryImpl.kt
@@ -1,0 +1,53 @@
+package com.iti.skypulse.data.repository
+
+import com.iti.skypulse.core.error.AppException
+import com.iti.skypulse.core.network.ConnectivityHelper
+import com.iti.skypulse.data.local.datasource.WeatherLocalDataSource
+import com.iti.skypulse.data.model.ForecastModel
+import com.iti.skypulse.data.model.WeatherModel
+import com.iti.skypulse.data.model.mapper.toForecastEntity
+import com.iti.skypulse.data.model.mapper.toForecastModel
+import com.iti.skypulse.data.model.mapper.toWeatherEntity
+import com.iti.skypulse.data.model.mapper.toWeatherModel
+import com.iti.skypulse.data.remote.datasource.WeatherRemoteDataSource
+
+class WeatherRepositoryImpl(
+    private val remoteDataSource: WeatherRemoteDataSource,
+    private val localDataSource: WeatherLocalDataSource,
+    private val connectivityHelper: ConnectivityHelper
+) : WeatherRepository {
+
+    override suspend fun getCurrentWeather(
+        latitude: Double,
+        longitude: Double
+    ): Result<WeatherModel> {
+        return runCatching {
+            val cacheKey = buildCacheKey(latitude, longitude)
+            val cached = localDataSource.getWeather(cacheKey)
+            if (connectivityHelper.isOnline()) {
+                val fresh = remoteDataSource.getCurrentWeather(latitude, longitude).toWeatherModel()
+                localDataSource.saveWeather(fresh.toWeatherEntity(cacheKey))
+                fresh
+            } else cached?.toWeatherModel() ?: throw AppException.NoCacheException()
+        }
+    }
+
+    override suspend fun getFiveDayForecast(
+        latitude: Double,
+        longitude: Double
+    ): Result<ForecastModel> {
+        return runCatching {
+            val cacheKey = buildCacheKey(latitude, longitude)
+            val cached = localDataSource.getForecast(cacheKey)
+            if (connectivityHelper.isOnline()) {
+                val fresh = remoteDataSource.getFiveDayForecast(latitude, longitude).toForecastModel()
+                localDataSource.saveForecast(fresh.toForecastEntity(cacheKey))
+                fresh
+            } else cached?.toForecastModel() ?: throw AppException.NoCacheException()
+        }
+    }
+
+    private fun buildCacheKey(latitude: Double, longitude: Double): String {
+        return "${"%.2f".format(latitude)},${"%.2f".format(longitude)}"
+    }
+}

--- a/app/src/main/java/com/iti/skypulse/di/ServiceLocator.kt
+++ b/app/src/main/java/com/iti/skypulse/di/ServiceLocator.kt
@@ -3,6 +3,9 @@ package com.iti.skypulse.di
 import android.app.Application
 import com.iti.skypulse.data.local.prefs.AppPreferences
 import com.iti.skypulse.data.local.location.LocationHelper
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import java.util.Locale
 
 object ServiceLocator {
     private lateinit var appContext: Application

--- a/app/src/main/java/com/iti/skypulse/di/ServiceLocator.kt
+++ b/app/src/main/java/com/iti/skypulse/di/ServiceLocator.kt
@@ -1,11 +1,19 @@
 package com.iti.skypulse.di
 
 import android.app.Application
-import com.iti.skypulse.data.local.prefs.AppPreferences
+import android.net.ConnectivityManager
+import android.content.Context
+import com.iti.skypulse.core.network.ConnectivityHelper
+import com.iti.skypulse.data.local.datasource.WeatherLocalDataSourceImpl
 import com.iti.skypulse.data.local.location.LocationHelper
-import kotlinx.coroutines.flow.first
+import com.iti.skypulse.data.local.prefs.AppPreferences
+import com.iti.skypulse.data.local.room.AppDatabase
+import com.iti.skypulse.data.remote.api.ApiClient
+import com.iti.skypulse.data.remote.api.WeatherApiService
+import com.iti.skypulse.data.remote.datasource.WeatherRemoteDataSourceImpl
+import com.iti.skypulse.data.repository.WeatherRepositoryImpl
 import kotlinx.coroutines.runBlocking
-import java.util.Locale
+import kotlinx.coroutines.flow.first
 
 object ServiceLocator {
     private lateinit var appContext: Application
@@ -20,5 +28,37 @@ object ServiceLocator {
 
     val locationHelper: LocationHelper by lazy {
         LocationHelper(appContext)
+    }
+
+    val connectivityHelper: ConnectivityHelper by lazy {
+        ConnectivityHelper(
+            appContext.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+        )
+    }
+
+    private val appDatabase: AppDatabase by lazy {
+        AppDatabase.getInstance(appContext)
+    }
+
+    private val weatherApiService: WeatherApiService by lazy {
+        val langCode = runBlocking { appPreferences.language.first() }
+        ApiClient.init(langCode)
+        ApiClient.getInstance().create(WeatherApiService::class.java)
+    }
+
+    private val weatherRemoteDataSource by lazy {
+        WeatherRemoteDataSourceImpl(weatherApiService)
+    }
+
+    private val weatherLocalDataSource by lazy {
+        WeatherLocalDataSourceImpl(appDatabase.weatherDao())
+    }
+
+    val weatherRepository by lazy {
+        WeatherRepositoryImpl(
+            remoteDataSource = weatherRemoteDataSource,
+            localDataSource = weatherLocalDataSource,
+            connectivityHelper = connectivityHelper
+        )
     }
 }

--- a/app/src/main/java/com/iti/skypulse/ui/components/ShimmerBox.kt
+++ b/app/src/main/java/com/iti/skypulse/ui/components/ShimmerBox.kt
@@ -1,0 +1,30 @@
+package com.iti.skypulse.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.valentinilk.shimmer.shimmer
+
+@Composable
+fun ShimmerBox(
+    modifier: Modifier = Modifier,
+    height: Dp = 60.dp,
+    cornerRadius: Dp = 16.dp
+) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(height)
+            .shimmer()
+            .clip(RoundedCornerShape(cornerRadius))
+            .background(MaterialTheme.colorScheme.onBackground.copy(alpha = 0.1f))
+    )
+}

--- a/app/src/main/java/com/iti/skypulse/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/iti/skypulse/ui/home/HomeScreen.kt
@@ -6,54 +6,99 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.slideInVertically
 import androidx.compose.foundation.LocalOverscrollFactory
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.iti.skypulse.ui.home.animation.rememberHomeAnimationStep
 import com.iti.skypulse.R
 import com.iti.skypulse.ui.components.PrimaryAppBar
 import com.iti.skypulse.ui.home.components.CurrentWeatherCard
+import com.iti.skypulse.ui.home.components.HomeShimmer
 import com.iti.skypulse.ui.home.components.HourlyForecast
 import com.iti.skypulse.ui.home.components.WeatherDetails
+import com.iti.skypulse.ui.preferences.LocalPreferencesViewModel
+import com.iti.skypulse.ui.theme.AppTypography
 import com.iti.skypulse.ui.theme.SkyPulseTheme
-
 @Composable
-fun HomeScreen() {
+fun HomeScreen(
+    viewModel: HomeViewModel = viewModel(factory = HomeViewModelFactory())
+) {
+    val uiState by viewModel.uiState.collectAsState()
     val animationStep by rememberHomeAnimationStep()
-
     val enterAnimation = fadeIn(tween(400)) + slideInVertically(tween(400)) { it / 4 }
 
     CompositionLocalProvider(LocalOverscrollFactory provides null) {
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .verticalScroll(rememberScrollState())
                 .background(MaterialTheme.colorScheme.background)
         ) {
+
             PrimaryAppBar(
                 title = stringResource(R.string.app_title),
-                location = "Awsim, Giza"
+                location = when (val state = uiState) {
+                    is HomeUiState.Success -> state.weather.cityName
+                    else -> null
+                }
             )
 
-            Column(modifier = Modifier.padding(horizontal = 20.dp)) {
-                AnimatedVisibility(visible = animationStep >= 1, enter = enterAnimation) {
-                    CurrentWeatherCard()
+            when (val state = uiState) {
+                is HomeUiState.Loading -> HomeShimmer()
+
+                is HomeUiState.Error -> {
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text(
+                            text = stringResource(state.messageRes),
+                            style = AppTypography.medium16,
+                            color = MaterialTheme.colorScheme.error
+                        )
+                    }
                 }
-                AnimatedVisibility(visible = animationStep >= 2, enter = enterAnimation) {
-                    HourlyForecast()
-                }
-                AnimatedVisibility(visible = animationStep >= 3, enter = enterAnimation) {
-                    WeatherDetails()
+
+                is HomeUiState.Success -> {
+                    val preferencesViewModel = LocalPreferencesViewModel.current
+                    val tempUnit by preferencesViewModel.tempUnit.collectAsState()
+                    val pressureUnit by preferencesViewModel.pressureUnit.collectAsState()
+                    val windUnit by preferencesViewModel.windUnit.collectAsState()
+
+                    Column(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .verticalScroll(rememberScrollState())
+                            .padding(horizontal = 20.dp)
+                    ) {
+                        AnimatedVisibility(visible = animationStep >= 1, enter = enterAnimation) {
+                            CurrentWeatherCard(weather = state.weather, tempUnit= tempUnit)
+                        }
+                        AnimatedVisibility(visible = animationStep >= 2, enter = enterAnimation) {
+                            HourlyForecast(items = state.hourlyForecasts, tempUnit= tempUnit)
+                        }
+                        AnimatedVisibility(visible = animationStep >= 3, enter = enterAnimation) {
+                            WeatherDetails(
+                                weather = state.weather,
+                                pressureUnit = pressureUnit,
+                                windUnit = windUnit
+                            )
+                        }
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/iti/skypulse/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/iti/skypulse/ui/home/HomeViewModel.kt
@@ -1,0 +1,115 @@
+package com.iti.skypulse.ui.home
+
+import androidx.annotation.StringRes
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.iti.skypulse.R
+import com.iti.skypulse.core.error.toMessageRes
+import com.iti.skypulse.core.utils.TempUnit
+import com.iti.skypulse.data.local.location.LocationHelper
+import com.iti.skypulse.data.local.prefs.AppPreferences
+import com.iti.skypulse.data.model.HourlyForecastModel
+import com.iti.skypulse.data.model.LocationProvider
+import com.iti.skypulse.data.model.SavedLocation
+import com.iti.skypulse.data.model.WeatherModel
+import com.iti.skypulse.data.repository.WeatherRepository
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+class HomeViewModel(
+    private val weatherRepository: WeatherRepository,
+    private val appPreferences: AppPreferences,
+    private val locationHelper: LocationHelper
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow<HomeUiState>(HomeUiState.Loading)
+    val uiState: StateFlow<HomeUiState> = _uiState
+
+    private val _tempUnit = MutableStateFlow(TempUnit.CELSIUS)
+    val tempUnit: StateFlow<TempUnit> = _tempUnit
+
+    init {
+        viewModelScope.launch {
+            appPreferences.tempUnit.collect { _tempUnit.value = it }
+        }
+        loadWeather()
+    }
+
+    private fun loadWeather() {
+        viewModelScope.launch {
+            _uiState.value = HomeUiState.Loading
+
+            val location = resolveLocation()
+            if (location == null) {
+                _uiState.value = HomeUiState.Error(R.string.error_no_location)
+                return@launch
+            }
+
+            fetchWeather(location.lat, location.lng)
+        }
+    }
+
+    private suspend fun resolveLocation(): SavedLocation? {
+        return getGpsLocation() ?: getSavedLocation()
+    }
+
+    private suspend fun getGpsLocation(): SavedLocation? {
+        return locationHelper.getLocation()
+            .getOrNull()
+            ?.let { location ->
+                SavedLocation(
+                    lat = location.latitude,
+                    lng = location.longitude,
+                    provider = LocationProvider.GPS
+                ).also { appPreferences.saveLocation(it) }
+            }
+    }
+
+    private suspend fun getSavedLocation(): SavedLocation? {
+        return appPreferences.getSavedLocation()
+    }
+
+    private suspend fun fetchWeather(latitude: Double, longitude: Double) {
+        val address = locationHelper.getAddressFromLocation(latitude, longitude)
+
+        val weatherDeferred = viewModelScope.async {
+            weatherRepository.getCurrentWeather(latitude, longitude)
+        }
+        val forecastDeferred = viewModelScope.async {
+            weatherRepository.getFiveDayForecast(latitude, longitude)
+        }
+
+        val weatherResult = weatherDeferred.await()
+        val forecastResult = forecastDeferred.await()
+
+        if (weatherResult.isFailure) {
+            _uiState.value = HomeUiState.Error(weatherResult.exceptionOrNull().toMessageRes())
+            return
+        }
+
+        val weather = weatherResult.getOrThrow()
+        val hourlyForecasts = forecastResult.getOrNull()
+            ?.dailyForecasts
+            ?.firstOrNull()
+            ?.hourlyForecasts
+            ?: emptyList()
+
+        _uiState.value = HomeUiState.Success(
+            weather = weather,
+            hourlyForecasts = hourlyForecasts,
+            address = address
+        )
+    }
+}
+
+sealed class HomeUiState {
+    object Loading : HomeUiState()
+    data class Success(
+        val weather: WeatherModel,
+        val hourlyForecasts: List<HourlyForecastModel>,
+        val address: String?
+    ) : HomeUiState()
+    data class Error(@param:StringRes val messageRes: Int) : HomeUiState()
+}

--- a/app/src/main/java/com/iti/skypulse/ui/home/HomeViewModelFactory.kt
+++ b/app/src/main/java/com/iti/skypulse/ui/home/HomeViewModelFactory.kt
@@ -1,0 +1,16 @@
+package com.iti.skypulse.ui.home
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.iti.skypulse.di.ServiceLocator
+
+class HomeViewModelFactory : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        @Suppress("UNCHECKED_CAST")
+        return HomeViewModel(
+            weatherRepository = ServiceLocator.weatherRepository,
+            appPreferences = ServiceLocator.appPreferences,
+            locationHelper = ServiceLocator.locationHelper
+        ) as T
+    }
+}

--- a/app/src/main/java/com/iti/skypulse/ui/home/components/CurrentWeatherCard.kt
+++ b/app/src/main/java/com/iti/skypulse/ui/home/components/CurrentWeatherCard.kt
@@ -12,22 +12,20 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.iti.skypulse.data.model.WeatherModel
 import com.iti.skypulse.ui.components.PrimaryCard
 import com.iti.skypulse.ui.components.WeatherIcon
 import com.iti.skypulse.ui.theme.AppTypography
 import com.iti.skypulse.ui.theme.SkyPulseTheme
-
+import com.iti.skypulse.core.utils.TempUnit
+import com.iti.skypulse.core.utils.UnitConverter
 
 
 @Composable
 fun CurrentWeatherCard(
+    weather: WeatherModel,
     modifier: Modifier = Modifier,
-    temperature: String = "72°F",
-    condition: String = "Partly Cloudy",
-    feelsLike: String = "Feels like 75°F",
-    high: String = "78°",
-    low: String = "64°",
-    weatherIconCode: String = "02d"
+    tempUnit: TempUnit
 ) {
     PrimaryCard(
         modifier = modifier
@@ -41,27 +39,25 @@ fun CurrentWeatherCard(
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             WeatherIcon(
-                iconCode = weatherIconCode,
-                contentDescription = condition,
+                iconCode = weather.weatherIconCode,
+                contentDescription = weather.weatherDescription,
                 modifier = Modifier.size(96.dp).padding(bottom = 8.dp)
             )
 
             Text(
-                text = temperature,
-                style = AppTypography.bold56.copy(
-                    letterSpacing = (-2).sp
-                ),
+                text = UnitConverter.formatTemp(weather.temperature, tempUnit).display(),
+                style = AppTypography.bold56.copy(letterSpacing = (-2).sp),
                 color = MaterialTheme.colorScheme.onBackground
             )
 
             Text(
-                text = condition,
+                text = weather.weatherDescription,
                 style = AppTypography.medium16,
                 color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.8f)
             )
 
             Text(
-                text = feelsLike,
+                text = UnitConverter.formatTemp(weather.feelsLikeTemperature, tempUnit).display(),
                 style = AppTypography.regular12,
                 color = MaterialTheme.colorScheme.onSecondary
             )
@@ -72,13 +68,18 @@ fun CurrentWeatherCard(
                 horizontalArrangement = Arrangement.spacedBy(16.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                TempPill(label = high, isHigh = true)
-                TempPill(label = low, isHigh = false)
+                TempPill(
+                    label = UnitConverter.formatTemp(weather.maximumTemperature, tempUnit).display(),
+                    isHigh = true
+                )
+                TempPill(
+                    label = UnitConverter.formatTemp(weather.minimumTemperature, tempUnit).display(),
+                    isHigh = false
+                )
             }
         }
     }
 }
-
 @Composable
 fun TempPill(label: String, isHigh: Boolean) {
     val icon = if (isHigh) Icons.Filled.ArrowUpward else Icons.Filled.ArrowDownward
@@ -113,6 +114,23 @@ fun TempPill(label: String, isHigh: Boolean) {
 @Composable
 fun CardPreview() {
     SkyPulseTheme {
-        CurrentWeatherCard()
+        CurrentWeatherCard(
+            tempUnit = TempUnit.CELSIUS,
+            weather = WeatherModel(
+                temperature = 295.0,
+                feelsLikeTemperature = 293.0,
+                minimumTemperature = 287.0,
+                maximumTemperature = 298.0,
+                weatherDescription = "Partly Cloudy",
+                weatherIconCode = "02d",
+                windSpeed = 5.0,
+                windDirectionDegrees = 180,
+                humidityPercentage = 60,
+                visibilityInMeters = 10000,
+                atmosphericPressure = 1015,
+                cityName = "Cairo",
+                countryCode = "EG"
+            )
+        )
     }
 }

--- a/app/src/main/java/com/iti/skypulse/ui/home/components/HomeShimmer.kt
+++ b/app/src/main/java/com/iti/skypulse/ui/home/components/HomeShimmer.kt
@@ -1,0 +1,68 @@
+package com.iti.skypulse.ui.home.components
+
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.iti.skypulse.ui.components.ShimmerBox
+
+@Composable
+fun HomeShimmer() {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = 20.dp)
+    ) {
+        Spacer(modifier = Modifier.height(16.dp))
+
+        ShimmerBox(height = 220.dp)
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        ShimmerBox(height = 20.dp, cornerRadius = 8.dp)
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Row(modifier = Modifier.fillMaxWidth()) {
+            repeat(4) {
+                ShimmerBox(
+                    modifier = Modifier.weight(1f),
+                    height = 100.dp
+                )
+                if (it < 3) Spacer(modifier = Modifier.width(12.dp))
+            }
+        }
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        ShimmerBox(height = 20.dp, cornerRadius = 8.dp)
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        repeat(2) {
+            Row(modifier = Modifier.fillMaxWidth()) {
+                ShimmerBox(
+                    modifier = Modifier.weight(1f),
+                    height = 100.dp
+                )
+                Spacer(modifier = Modifier.width(16.dp))
+                ShimmerBox(
+                    modifier = Modifier.weight(1f),
+                    height = 100.dp
+                )
+            }
+            Spacer(modifier = Modifier.height(16.dp))
+        }
+    }
+}

--- a/app/src/main/java/com/iti/skypulse/ui/home/components/HourlyForecast.kt
+++ b/app/src/main/java/com/iti/skypulse/ui/home/components/HourlyForecast.kt
@@ -32,6 +32,9 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.iti.skypulse.R
+import com.iti.skypulse.core.utils.TempUnit
+import com.iti.skypulse.core.utils.UnitConverter
+import com.iti.skypulse.data.model.HourlyForecastModel
 import com.iti.skypulse.ui.components.PrimaryCard
 import com.iti.skypulse.ui.components.WeatherIcon
 import com.iti.skypulse.ui.theme.AppTypography
@@ -43,19 +46,15 @@ data class HourlyForecastData(
     val temperature: String
 )
 
-val sampleHourlyData = listOf(
-    HourlyForecastData("Now",  "01d", "72°"),
-    HourlyForecastData("2 PM", "02d", "72°"),
-    HourlyForecastData("3 PM", "03d", "71°"),
-    HourlyForecastData("4 PM", "10d", "69°"),
-    HourlyForecastData("5 PM", "10n", "68°")
-)
 
 @Composable
 fun HourlyForecast(
-    items: List<HourlyForecastData> = sampleHourlyData
+    items: List<HourlyForecastModel>,
+    tempUnit: TempUnit
+
 ) {
     var selectedIndex by remember { mutableIntStateOf(0) }
+
 
     Column(
         modifier = Modifier
@@ -76,7 +75,12 @@ fun HourlyForecast(
         ) {
             itemsIndexed(items) { index, item ->
                 HourlyForecastItem(
-                    data = item,
+                    data = HourlyForecastData(
+                        time = item.time,
+                        iconCode = item.weatherIconCode,
+                        temperature = UnitConverter
+                            .formatTemp(item.temperature, tempUnit).display()
+                    ),
                     isSelected = index == selectedIndex,
                     onClick = { selectedIndex = index }
                 )
@@ -102,6 +106,7 @@ fun HourlyForecastItem(
         label = "bg"
     )
     val textColorTime = if (isSelected) Color.White.copy(alpha = 0.7f)
+
     else MaterialTheme.colorScheme.onSecondary
     val textColorTemp = if (isSelected) Color.White
     else MaterialTheme.colorScheme.onBackground
@@ -150,6 +155,15 @@ fun HourlyForecastItem(
 @Composable
 fun HourlyForecastPreview() {
     SkyPulseTheme {
-        HourlyForecast()
+        HourlyForecast(
+            tempUnit = TempUnit.CELSIUS,
+            items = listOf(
+                HourlyForecastModel(time = "Now",   weatherIconCode = "01d", temperature = 22.0),
+                HourlyForecastModel(time = "14:00", weatherIconCode = "02d", temperature = 21.0),
+                HourlyForecastModel(time = "15:00", weatherIconCode = "03d", temperature = 20.0),
+                HourlyForecastModel(time = "16:00", weatherIconCode = "10d", temperature = 19.0),
+                HourlyForecastModel(time = "17:00", weatherIconCode = "10n", temperature = 18.0),
+            )
+        )
     }
 }

--- a/app/src/main/java/com/iti/skypulse/ui/home/components/WeatherDetails.kt
+++ b/app/src/main/java/com/iti/skypulse/ui/home/components/WeatherDetails.kt
@@ -18,6 +18,10 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.iti.skypulse.R
+import com.iti.skypulse.core.utils.PressureUnit
+import com.iti.skypulse.core.utils.UnitConverter
+import com.iti.skypulse.core.utils.WindUnit
+import com.iti.skypulse.data.model.WeatherModel
 import com.iti.skypulse.ui.components.PrimaryCard
 import com.iti.skypulse.ui.theme.AppTypography
 import com.iti.skypulse.ui.theme.SkyPulseTheme
@@ -29,17 +33,42 @@ data class WeatherDetailData(
     val subtext: String
 )
 
-val sampleWeatherDetails = listOf(
-    WeatherDetailData(Icons.Rounded.Air,          "Wind",       "12 mph",   "Direction: NW"),
-    WeatherDetailData(Icons.Rounded.WaterDrop,    "Humidity",   "45 %",     "Dew point: 52°"),
-    WeatherDetailData(Icons.Rounded.RemoveRedEye, "Visibility", "10 mi",    "Clear sky"),
-    WeatherDetailData(Icons.Rounded.Speed,        "Pressure",   "1015 hPa", "Stable"),
-)
-
 @Composable
 fun WeatherDetails(
-    items: List<WeatherDetailData> = sampleWeatherDetails
+    weather: WeatherModel,
+    windUnit: WindUnit,
+    pressureUnit: PressureUnit
 ) {
+    val items = listOf(
+        WeatherDetailData(
+            icon = Icons.Rounded.Air,
+            label = stringResource(R.string.wind),
+            value = UnitConverter.formatWind(weather.windSpeed, windUnit).display(),
+            subtext = stringResource(R.string.wind_direction, weather.windDirectionDegrees)
+        ),
+        WeatherDetailData(
+            icon = Icons.Rounded.WaterDrop,
+            label = stringResource(R.string.humidity),
+            value = stringResource(R.string.humidity_value, weather.humidityPercentage),
+            subtext = stringResource(R.string.atmospheric_moisture)
+        ),
+        WeatherDetailData(
+            icon = Icons.Rounded.RemoveRedEye,
+            label = stringResource(R.string.visibility),
+            value = stringResource(R.string.visibility_value, weather.visibilityInMeters / 1000),
+            subtext = stringResource(
+                if (weather.visibilityInMeters >= 10000) R.string.clear_sky
+                else R.string.limited_visibility
+            )
+        ),
+        WeatherDetailData(
+            icon = Icons.Rounded.Speed,
+            label = stringResource(R.string.pressure),
+            value = UnitConverter.formatPressure(weather.atmosphericPressure, pressureUnit).display(),
+            subtext = stringResource(R.string.atmospheric_pressure)
+        )
+    )
+
     Column(
         modifier = Modifier
             .fillMaxWidth()
@@ -69,7 +98,6 @@ fun WeatherDetails(
         }
     }
 }
-
 @Composable
 fun WeatherDetailCard(
     data: WeatherDetailData,
@@ -123,6 +151,24 @@ fun WeatherDetailCard(
 @Composable
 fun WeatherDetailsPreview() {
     SkyPulseTheme {
-        WeatherDetails()
+        WeatherDetails(
+            windUnit = WindUnit.METERS_PER_SECOND,
+            pressureUnit = PressureUnit.HPA,
+            weather = WeatherModel(
+                temperature = 295.0,
+                feelsLikeTemperature = 293.0,
+                minimumTemperature = 287.0,
+                maximumTemperature = 298.0,
+                weatherDescription = "Partly Cloudy",
+                weatherIconCode = "02d",
+                windSpeed = 5.14,
+                windDirectionDegrees = 180,
+                humidityPercentage = 59,
+                visibilityInMeters = 10000,
+                atmosphericPressure = 1021,
+                cityName = "Cairo",
+                countryCode = "EG"
+            )
+        )
     }
 }

--- a/app/src/main/java/com/iti/skypulse/ui/preferences/LocalPreferences.kt
+++ b/app/src/main/java/com/iti/skypulse/ui/preferences/LocalPreferences.kt
@@ -1,0 +1,7 @@
+package com.iti.skypulse.ui.preferences
+
+import androidx.compose.runtime.compositionLocalOf
+
+val LocalPreferencesViewModel = compositionLocalOf<PreferencesViewModel> {
+    error("No PreferencesViewModel provided")
+}

--- a/app/src/main/java/com/iti/skypulse/ui/preferences/PreferencesViewModel.kt
+++ b/app/src/main/java/com/iti/skypulse/ui/preferences/PreferencesViewModel.kt
@@ -1,0 +1,37 @@
+package com.iti.skypulse.ui.preferences
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.iti.skypulse.core.utils.PressureUnit
+import com.iti.skypulse.core.utils.TempUnit
+import com.iti.skypulse.core.utils.WindUnit
+import com.iti.skypulse.data.local.prefs.AppPreferences
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
+
+class PreferencesViewModel(
+    private val appPreferences: AppPreferences
+) : ViewModel() {
+
+    val tempUnit: StateFlow<TempUnit> = appPreferences.tempUnit
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = TempUnit.CELSIUS
+        )
+
+    val windUnit: StateFlow<WindUnit> = appPreferences.windUnit
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = WindUnit.METERS_PER_SECOND
+        )
+
+    val pressureUnit: StateFlow<PressureUnit> = appPreferences.pressureUnit
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = PressureUnit.HPA
+        )
+}

--- a/app/src/main/java/com/iti/skypulse/ui/preferences/PreferencesViewModelFactory.kt
+++ b/app/src/main/java/com/iti/skypulse/ui/preferences/PreferencesViewModelFactory.kt
@@ -1,0 +1,12 @@
+package com.iti.skypulse.ui.preferences
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.iti.skypulse.di.ServiceLocator
+
+class PreferencesViewModelFactory : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        @Suppress("UNCHECKED_CAST")
+        return PreferencesViewModel(ServiceLocator.appPreferences) as T
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -51,4 +51,30 @@
     <string name="location_cancel">Cancel</string>
     <string name="location_disabled_title">Location Is Disabled</string>
     <string name="location_disabled_message">Please enable location services in your device settings to use GPS.</string>
+    <string name="error_no_internet">No internet connection</string>
+    <string name="error_no_cache">No cached data available</string>
+    <string name="error_no_location">Unable to determine location</string>
+    <string name="error_generic">Something went wrong, please try again</string>
+    <string name="feels_like">Feels like %1$d°</string>
+    <string name="wind">Wind</string>
+    <string name="wind_direction">Direction: %1$d°</string>
+    <string name="humidity">Humidity</string>
+    <string name="atmospheric_moisture">Atmospheric moisture</string>
+    <string name="visibility">Visibility</string>
+    <string name="visibility_value">%1$d km</string>
+    <string name="clear_sky">Clear sky</string>
+    <string name="limited_visibility">Limited visibility</string>
+    <string name="pressure">Pressure</string>
+    <string name="atmospheric_pressure">Atmospheric pressure</string>
+    <string name="humidity_value">%1$d%%</string>
+    <string name="unit_celsius">°C</string>
+    <string name="unit_fahrenheit">°F</string>
+    <string name="unit_kelvin">K</string>
+    <string name="unit_ms">m/s</string>
+    <string name="unit_kmh">km/h</string>
+    <string name="unit_mph">mph</string>
+    <string name="unit_hpa">hPa</string>
+    <string name="unit_mbar">mbar</string>
+    <string name="unit_mmhg">mmHg</string>
+
 </resources>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,4 +3,6 @@ plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.kotlin.compose) apply false
     alias(libs.plugins.kotlin.serialization) apply false
+    alias(libs.plugins.ksp) apply false
+
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,7 +23,8 @@ playServicesLocation = "21.3.0"
 retrofit = "3.0.0"
 room = "2.8.4"
 ksp = "2.3.5"
-okhttp = "4.12.0"
+okhttp = "5.3.2"
+shimmerVersion = "1.3.3"
 
 [libraries]
 androidx-compose-material-icons-extended = { module = "androidx.compose.material:material-icons-extended" }
@@ -57,7 +58,7 @@ room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "
 room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
 room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
 okhttp-logging = { group = "com.squareup.okhttp3", name = "logging-interceptor", version.ref = "okhttp" }
-
+shimmer = { group = "com.valentinilk.shimmer", name = "compose-shimmer", version.ref = "shimmerVersion" }
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 agp = "9.0.1"
 coilCompose = "2.7.0"
+converterGson = "3.0.0"
 coreKtx = "1.17.0"
 coreSplashscreen = "1.2.0"
 datastorePreferences = "1.2.0"
@@ -15,10 +16,14 @@ kotlin = "2.3.10"
 composeBom = "2026.02.01"
 material = "1.13.0"
 navigationCompose = "2.9.7"
-animationGraphics = "1.10.3"
+animationGraphics = "1.10.4"
 appcompat = "1.7.1"
 kotlinxSerialization = "1.10.0"
 playServicesLocation = "21.3.0"
+retrofit = "3.0.0"
+room = "2.8.4"
+ksp = "2.3.5"
+okhttp = "4.12.0"
 
 [libraries]
 androidx-compose-material-icons-extended = { module = "androidx.compose.material:material-icons-extended" }
@@ -29,6 +34,7 @@ androidx-datastore-preferences-core = { module = "androidx.datastore:datastore-p
 androidx-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "lifecycleRuntimeKtx" }
 androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "navigationCompose" }
 coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coilCompose" }
+converter-gson = { module = "com.squareup.retrofit2:converter-gson", version.ref = "converterGson" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
@@ -46,8 +52,14 @@ androidx-compose-animation-graphics = { group = "androidx.compose.animation", na
 kotlinx-coroutines-play-services = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-play-services", version.ref = "kotlinxCoroutinesPlayServices" }
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
 play-services-location = { group = "com.google.android.gms", name = "play-services-location", version.ref = "playServicesLocation" }
+retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
+room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
+room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
+room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
+okhttp-logging = { group = "com.squareup.okhttp3", name = "logging-interceptor", version.ref = "okhttp" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }


### PR DESCRIPTION
## Summary
This PR introduces the core weather data infrastructure, including networking, offline caching, and Home screen integration.

## Changes
- Implemented **Retrofit + OkHttp** networking layer with automatic API key and language parameters.
- Added **DTOs, domain models, and WeatherMapper** for transforming API responses.
- Implemented **WeatherRemoteDataSource** and **WeatherLocalDataSource**.
- Added **Room database** with `WeatherEntity`, `ForecastEntity`, and `WeatherDao`.
- Implemented **offline-first repository** with connectivity checks and local caching.
- Created **HomeViewModel** and integrated real weather data into the Home screen UI.
- Added **unit conversion** support for temperature, wind, and pressure based on user preferences.
- Implemented **AppPreferences** for language and unit settings.
- Added **loading shimmer UI** for the Home screen.
- Refactored `WeatherDao` to use `cacheKey` instead of `cityName` for more reliable caching.

## Result
The app can now fetch weather data from the API, cache it locally, support offline usage, and display dynamic weather information on the Home screen based on user preferences.