### PR TITLE
Refactor weather and forecast caching to support multi-language data and improve favorite management.

### DIFF
--- a/app/src/main/java/com/iti/skypulse/SkyPulseApp.kt
+++ b/app/src/main/java/com/iti/skypulse/SkyPulseApp.kt
@@ -3,9 +3,7 @@ package com.iti.skypulse
 import android.app.Application
 import com.google.android.gms.maps.MapsInitializer
 import com.iti.skypulse.di.ServiceLocator
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.MainScope
-import kotlinx.coroutines.launch
+
 
 class SkyPulseApp : Application() {
     override fun onCreate() {

--- a/app/src/main/java/com/iti/skypulse/data/local/datasource/WeatherLocalDataSource.kt
+++ b/app/src/main/java/com/iti/skypulse/data/local/datasource/WeatherLocalDataSource.kt
@@ -1,22 +1,25 @@
 package com.iti.skypulse.data.local.datasource
 
 import com.iti.skypulse.data.local.room.entity.ForecastEntity
+import com.iti.skypulse.data.local.room.entity.LatLngEntity
 import com.iti.skypulse.data.local.room.entity.WeatherEntity
 import com.iti.skypulse.data.local.room.entity.WeatherWithForecast
 import kotlinx.coroutines.flow.Flow
 
 interface WeatherLocalDataSource {
-    suspend fun getWeather(cacheKey: String): WeatherEntity?
+    suspend fun getWeather(cacheKey: String, lang: String): WeatherEntity?
     suspend fun saveWeather(weather: WeatherEntity)
     suspend fun deleteWeather(cacheKey: String)
 
-    suspend fun getForecast(cacheKey: String): ForecastEntity?
+    suspend fun getForecast(cacheKey: String, lang: String): ForecastEntity?
     suspend fun saveForecast(forecast: ForecastEntity)
     suspend fun deleteForecast(cacheKey: String)
 
-    fun getFavorites(): Flow<List<WeatherWithForecast>>
+    fun getFavorites(lang: String): Flow<List<WeatherWithForecast>>
     suspend fun markAsFavorite(cacheKey: String)
     suspend fun unmarkAsFavorite(cacheKey: String)
-
     suspend fun isFavorite(cacheKey: String): Boolean
+
+    suspend fun getAllFavoriteLocations(): List<LatLngEntity>
+
 }

--- a/app/src/main/java/com/iti/skypulse/data/local/datasource/WeatherLocalDataSourceImpl.kt
+++ b/app/src/main/java/com/iti/skypulse/data/local/datasource/WeatherLocalDataSourceImpl.kt
@@ -8,16 +8,18 @@ class WeatherLocalDataSourceImpl(
     private val weatherDao: WeatherDao
 ) : WeatherLocalDataSource {
 
-    override suspend fun getWeather(cacheKey: String): WeatherEntity? = weatherDao.getWeather(cacheKey)
+    override suspend fun getWeather(cacheKey: String, lang: String) = weatherDao.getWeather(cacheKey, lang)
     override suspend fun saveWeather(weather: WeatherEntity) = weatherDao.saveWeather(weather)
     override suspend fun deleteWeather(cacheKey: String) = weatherDao.deleteWeather(cacheKey)
 
-    override suspend fun getForecast(cacheKey: String): ForecastEntity? = weatherDao.getForecast(cacheKey)
+    override suspend fun getForecast(cacheKey: String, lang: String) = weatherDao.getForecast(cacheKey, lang)
     override suspend fun saveForecast(forecast: ForecastEntity) = weatherDao.saveForecast(forecast)
     override suspend fun deleteForecast(cacheKey: String) = weatherDao.deleteForecast(cacheKey)
 
-    override fun getFavorites() = weatherDao.getFavorites()
+    override fun getFavorites(lang: String) = weatherDao.getFavorites(lang)
     override suspend fun markAsFavorite(cacheKey: String) = weatherDao.markAsFavorite(cacheKey)
     override suspend fun unmarkAsFavorite(cacheKey: String) = weatherDao.unmarkAsFavorite(cacheKey)
     override suspend fun isFavorite(cacheKey: String) = weatherDao.isFavorite(cacheKey)
+    override suspend fun getAllFavoriteLocations() = weatherDao.getAllFavoriteLocations()
+
 }

--- a/app/src/main/java/com/iti/skypulse/data/local/room/dao/WeatherDao.kt
+++ b/app/src/main/java/com/iti/skypulse/data/local/room/dao/WeatherDao.kt
@@ -6,14 +6,14 @@ import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Transaction
 import com.iti.skypulse.data.local.room.entity.ForecastEntity
+import com.iti.skypulse.data.local.room.entity.LatLngEntity
 import com.iti.skypulse.data.local.room.entity.WeatherEntity
 import com.iti.skypulse.data.local.room.entity.WeatherWithForecast
 import kotlinx.coroutines.flow.Flow
-
 @Dao
 interface WeatherDao {
-    @Query("SELECT * FROM weather WHERE cacheKey = :cacheKey")
-    suspend fun getWeather(cacheKey: String): WeatherEntity?
+    @Query("SELECT * FROM weather WHERE cacheKey = :cacheKey AND lang = :lang")
+    suspend fun getWeather(cacheKey: String, lang: String): WeatherEntity?
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun saveWeather(weather: WeatherEntity)
@@ -21,8 +21,8 @@ interface WeatherDao {
     @Query("DELETE FROM weather WHERE cacheKey = :cacheKey")
     suspend fun deleteWeather(cacheKey: String)
 
-    @Query("SELECT * FROM forecast WHERE cacheKey = :cacheKey")
-    suspend fun getForecast(cacheKey: String): ForecastEntity?
+    @Query("SELECT * FROM forecast WHERE cacheKey = :cacheKey AND lang = :lang")
+    suspend fun getForecast(cacheKey: String, lang: String): ForecastEntity?
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun saveForecast(forecast: ForecastEntity)
@@ -37,8 +37,8 @@ interface WeatherDao {
     suspend fun clearForecast()
 
     @Transaction
-    @Query("SELECT * FROM weather WHERE isFavorite = 1")
-    fun getFavorites(): Flow<List<WeatherWithForecast>>
+    @Query("SELECT * FROM weather WHERE isFavorite = 1 AND lang = :lang")
+    fun getFavorites(lang: String): Flow<List<WeatherWithForecast>>
 
     @Query("UPDATE weather SET isFavorite = 1 WHERE cacheKey = :cacheKey")
     suspend fun markAsFavorite(cacheKey: String)
@@ -49,4 +49,7 @@ interface WeatherDao {
     @Query("SELECT isFavorite FROM weather WHERE cacheKey = :cacheKey")
     suspend fun isFavorite(cacheKey: String): Boolean
 
+
+    @Query("SELECT latitude, longitude FROM weather WHERE isFavorite = 1 GROUP BY latitude, longitude")
+    suspend fun getAllFavoriteLocations(): List<LatLngEntity>
 }

--- a/app/src/main/java/com/iti/skypulse/data/local/room/entity/ForecastEntity.kt
+++ b/app/src/main/java/com/iti/skypulse/data/local/room/entity/ForecastEntity.kt
@@ -8,6 +8,7 @@ import com.iti.skypulse.data.model.DailyForecastModel
 data class ForecastEntity(
     @PrimaryKey
     val cacheKey: String,
+    val lang: String,
     val cityName: String,
     val latitude: Double,
     val longitude: Double,

--- a/app/src/main/java/com/iti/skypulse/data/local/room/entity/LatLngEntity.kt
+++ b/app/src/main/java/com/iti/skypulse/data/local/room/entity/LatLngEntity.kt
@@ -1,0 +1,4 @@
+package com.iti.skypulse.data.local.room.entity
+
+
+data class LatLngEntity(val latitude: Double, val longitude: Double)

--- a/app/src/main/java/com/iti/skypulse/data/local/room/entity/WeatherEntity.kt
+++ b/app/src/main/java/com/iti/skypulse/data/local/room/entity/WeatherEntity.kt
@@ -7,6 +7,7 @@ import androidx.room.PrimaryKey
 data class WeatherEntity(
     @PrimaryKey
     val cacheKey: String,
+    val lang: String,
     val cityName: String,
     val latitude: Double,
     val longitude: Double,

--- a/app/src/main/java/com/iti/skypulse/data/model/CacheKey.kt
+++ b/app/src/main/java/com/iti/skypulse/data/model/CacheKey.kt
@@ -1,5 +1,7 @@
 package com.iti.skypulse.data.model
 
-fun buildCacheKey(latitude: Double, longitude: Double, lang: String): String {
-    return "${"%.2f".format(latitude)},${"%.2f".format(longitude)},$lang"
+import java.util.Locale
+
+fun buildCacheKey(latitude: Double, longitude: Double): String {
+    return "%.2f,%.2f".format(Locale.US, latitude, longitude)
 }

--- a/app/src/main/java/com/iti/skypulse/data/model/mapper/WeatherMapper.kt
+++ b/app/src/main/java/com/iti/skypulse/data/model/mapper/WeatherMapper.kt
@@ -62,8 +62,9 @@ fun ForecastResponseDto.toForecastModel(): ForecastModel {
     )
 }
 
-fun WeatherModel.toWeatherEntity(cacheKey: String) = WeatherEntity(
+fun WeatherModel.toWeatherEntity(cacheKey: String, lang: String) = WeatherEntity(
     cacheKey = cacheKey,
+    lang = lang,
     cityName = cityName,
     countryCode = countryCode,
     temperature = temperature,
@@ -100,8 +101,9 @@ fun WeatherEntity.toWeatherModel() = WeatherModel(
     atmosphericPressure = atmosphericPressure
 )
 
-fun ForecastModel.toForecastEntity(cacheKey: String) = ForecastEntity(
+fun ForecastModel.toForecastEntity(cacheKey: String, lang: String) = ForecastEntity(
     cacheKey = cacheKey,
+    lang = lang,
     cityName = cityName,
     countryCode = countryCode,
     dailyForecasts = dailyForecasts,

--- a/app/src/main/java/com/iti/skypulse/data/repository/WeatherRepository.kt
+++ b/app/src/main/java/com/iti/skypulse/data/repository/WeatherRepository.kt
@@ -18,5 +18,4 @@ interface WeatherRepository {
 
     suspend fun refreshFavorite(latitude: Double, longitude: Double)
 
-
 }

--- a/app/src/main/java/com/iti/skypulse/data/repository/WeatherRepositoryImpl.kt
+++ b/app/src/main/java/com/iti/skypulse/data/repository/WeatherRepositoryImpl.kt
@@ -17,11 +17,12 @@ import com.iti.skypulse.data.model.mapper.toWeatherEntity
 import com.iti.skypulse.data.model.mapper.toWeatherModel
 import com.iti.skypulse.data.remote.datasource.WeatherRemoteDataSource
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 
 private const val CACHE_EXPIRY_MS = 30 * 60 * 1000L
-
 class WeatherRepositoryImpl(
     private val appPreferences: AppPreferences,
     private val remoteDataSource: WeatherRemoteDataSource,
@@ -31,11 +32,15 @@ class WeatherRepositoryImpl(
 
     override suspend fun getCurrentWeather(latitude: Double, longitude: Double): Result<WeatherModel> {
         return runCatching {
-            val cacheKey = getCacheKey(latitude, longitude)
-            val cached = localDataSource.getWeather(cacheKey)
+            val lang = getLang()
+            val cacheKey = buildCacheKey(latitude, longitude)
+            val cached = localDataSource.getWeather(cacheKey, lang)
             when {
                 cached != null && !isCacheExpired(cached.lastUpdated) -> cached.toWeatherModel()
-                connectivityHelper.isOnline() -> fetchAndSaveWeather(latitude, longitude, cacheKey)
+                connectivityHelper.isOnline() -> {
+                    val isFav = localDataSource.isFavorite(cacheKey)
+                    fetchAndSaveWeather(latitude, longitude, cacheKey, lang, isFav)
+                }
                 else -> cached?.toWeatherModel() ?: throw AppException.NoCacheException()
             }
         }
@@ -43,35 +48,35 @@ class WeatherRepositoryImpl(
 
     override suspend fun getFiveDayForecast(latitude: Double, longitude: Double): Result<ForecastModel> {
         return runCatching {
-            val cacheKey = getCacheKey(latitude, longitude)
-            val cached = localDataSource.getForecast(cacheKey)
+            val lang = getLang()
+            val cacheKey = buildCacheKey(latitude, longitude)
+            val cached = localDataSource.getForecast(cacheKey, lang)
             when {
                 cached != null && !isCacheExpired(cached.lastUpdated) -> cached.toForecastModel()
-                connectivityHelper.isOnline() -> fetchAndSaveForecast(latitude, longitude, cacheKey)
+                connectivityHelper.isOnline() -> fetchAndSaveForecast(latitude, longitude, cacheKey, lang)
                 else -> cached?.toForecastModel() ?: throw AppException.NoCacheException()
             }
         }
     }
 
-    override suspend fun searchPlaces(query: String): Result<List<GeoPlace>>{
+    override suspend fun searchPlaces(query: String): Result<List<GeoPlace>> {
         return runCatching {
-            val langCode = appPreferences.language.first().code
-            remoteDataSource.searchPlaces(query).map { dto -> dto.toGeoPlace(langCode)}
+            val langCode = getLang()
+            remoteDataSource.searchPlaces(query).map { dto -> dto.toGeoPlace(langCode) }
         }
     }
 
     override suspend fun addFavorite(latitude: Double, longitude: Double): Result<Unit> {
         return runCatching {
-            val cacheKey = getCacheKey(latitude, longitude)
-            val cachedWeather = localDataSource.getWeather(cacheKey)
-            val cachedForecast = localDataSource.getForecast(cacheKey)
-
+            val lang = getLang()
+            val cacheKey = buildCacheKey(latitude, longitude)
+            val cachedForecast = localDataSource.getForecast(cacheKey, lang)
             if (cachedForecast == null || isCacheExpired(cachedForecast.lastUpdated)) {
-                fetchAndSaveForecast(latitude, longitude, cacheKey)
+                fetchAndSaveForecast(latitude, longitude, cacheKey, lang)
             }
-
+            val cachedWeather = localDataSource.getWeather(cacheKey, lang)
             if (cachedWeather == null || isCacheExpired(cachedWeather.lastUpdated)) {
-                fetchAndSaveWeather(latitude, longitude, cacheKey, isFavorite = true)
+                fetchAndSaveWeather(latitude, longitude, cacheKey, lang, isFavorite = true)
             } else {
                 localDataSource.markAsFavorite(cacheKey)
             }
@@ -79,30 +84,44 @@ class WeatherRepositoryImpl(
     }
 
     override suspend fun removeFavorite(latitude: Double, longitude: Double) {
-        val cacheKey = getCacheKey(latitude, longitude)
+        val cacheKey = buildCacheKey(latitude, longitude)
         localDataSource.unmarkAsFavorite(cacheKey)
-
-        val homeLocation = appPreferences.savedLocation.first()
-        val isHomeLocation = homeLocation?.lat == latitude && homeLocation.lng == longitude
-
-        if (!isHomeLocation) {
-            localDataSource.deleteWeather(cacheKey)
-            localDataSource.deleteForecast(cacheKey)
-        }
     }
 
     override suspend fun refreshFavorite(latitude: Double, longitude: Double) {
         if (!connectivityHelper.isOnline()) return
         runCatching {
-            val cacheKey = getCacheKey(latitude, longitude)
-            fetchAndSaveWeather(latitude, longitude, cacheKey, isFavorite = true)
-            fetchAndSaveForecast(latitude, longitude, cacheKey)
+            val lang = getLang()
+            val cacheKey = buildCacheKey(latitude, longitude)
+            fetchAndSaveWeather(latitude, longitude, cacheKey, lang, isFavorite = true)
+            fetchAndSaveForecast(latitude, longitude, cacheKey, lang)
+        }
+    }
+    override fun getFavorites(): Flow<List<FavoriteWeather>> {
+        return flow {
+            val lang = getLang()
+            syncFavoritesForLanguage(lang)
+            emitAll(
+                localDataSource.getFavorites(lang)
+                    .map { entities -> entities.map { it.toFavoriteModel() } }
+            )
         }
     }
 
-    override fun getFavorites(): Flow<List<FavoriteWeather>> {
-        return localDataSource.getFavorites()
-            .map { entities -> entities.map { it.toFavoriteModel() } }
+    private suspend fun syncFavoritesForLanguage(lang: String) {
+        if (!connectivityHelper.isOnline()) return
+        val allFavorites = localDataSource.getAllFavoriteLocations()
+        allFavorites.forEach { (lat, lng) ->
+            val key = buildCacheKey(lat, lng)
+            val hasWeather = localDataSource.getWeather(key, lang) != null
+            val hasForecast = localDataSource.getForecast(key, lang) != null
+            if (!hasWeather || !hasForecast) {
+                runCatching {
+                    if (!hasWeather) fetchAndSaveWeather(lat, lng, key, lang, isFavorite = true)
+                    if (!hasForecast) fetchAndSaveForecast(lat, lng, key, lang)
+                }
+            }
+        }
     }
 
 
@@ -110,28 +129,27 @@ class WeatherRepositoryImpl(
         latitude: Double,
         longitude: Double,
         cacheKey: String,
+        lang: String,
         isFavorite: Boolean = false
     ): WeatherModel {
         val model = remoteDataSource.getCurrentWeather(latitude, longitude).toWeatherModel()
-        localDataSource.saveWeather(model.toWeatherEntity(cacheKey).copy(isFavorite = isFavorite))
+        localDataSource.saveWeather(model.toWeatherEntity(cacheKey, lang).copy(isFavorite = isFavorite))
         return model
     }
 
     private suspend fun fetchAndSaveForecast(
         latitude: Double,
         longitude: Double,
-        cacheKey: String
+        cacheKey: String,
+        lang: String
     ): ForecastModel {
         val model = remoteDataSource.getFiveDayForecast(latitude, longitude).toForecastModel()
-        localDataSource.saveForecast(model.toForecastEntity(cacheKey))
+        localDataSource.saveForecast(model.toForecastEntity(cacheKey, lang))
         return model
     }
 
     private fun isCacheExpired(lastUpdated: Long) =
         System.currentTimeMillis() - lastUpdated > CACHE_EXPIRY_MS
 
-    private suspend fun getCacheKey(latitude: Double, longitude: Double): String {
-        val lang = appPreferences.language.first().code
-        return buildCacheKey(latitude, longitude, lang)
-    }
+    private suspend fun getLang(): String = appPreferences.language.first().code
 }

--- a/app/src/main/java/com/iti/skypulse/data/repository/settings/SettingsRepositoryImpl.kt
+++ b/app/src/main/java/com/iti/skypulse/data/repository/settings/SettingsRepositoryImpl.kt
@@ -48,11 +48,10 @@ class SettingsRepositoryImpl(
     }
 
     override suspend fun saveLocation(location: SavedLocation) {
-        val lang = appPreferences.language.first().code
         val oldLocation = appPreferences.savedLocation.first()
 
         oldLocation?.let {
-            val oldCacheKey = buildCacheKey(it.lat, it.lng, lang)
+            val oldCacheKey = buildCacheKey(it.lat, it.lng)
             val isOldFavorite = weatherLocalDataSource.isFavorite(oldCacheKey)
 
             if (!isOldFavorite) {

--- a/app/src/main/java/com/iti/skypulse/ui/favorites/components/details/FavoriteDetailStatsGrid.kt
+++ b/app/src/main/java/com/iti/skypulse/ui/favorites/components/details/FavoriteDetailStatsGrid.kt
@@ -31,6 +31,7 @@ import com.iti.skypulse.ui.theme.AppTypography
 
 @Composable
 fun FavoriteDetailStatsGrid(weather: WeatherModel) {
+    // TODO : HANDLING THE UNIT CONVERSION
     val stats = listOf(
         Triple(stringResource(R.string.wind), "${weather.windSpeed} m/s", Icons.Rounded.Air),
         Triple(stringResource(R.string.humidity), "${weather.humidityPercentage}%", Icons.Rounded.WaterDrop),


### PR DESCRIPTION


- **Data Layer and Schema**:
    - Add `lang` field to `WeatherEntity` and `ForecastEntity` to allow language-specific caching.
    - Introduce `LatLngEntity` for structured coordinate retrieval.
    - Update `WeatherDao` to query records based on both `cacheKey` and `lang`.
    - Add `getAllFavoriteLocations` to `WeatherDao` to facilitate batch synchronization.

- **Caching and Repository Logic**:
    - Simplify `buildCacheKey` to use only coordinates (latitude/longitude) with a fixed `Locale.US` format.
    - Enhance `WeatherRepositoryImpl` to handle language-aware fetching; it now retrieves data based on the current app language and triggers a sync for missing translations.
    - Implement a synchronization mechanism in `getFavorites` to fetch weather data for favorite locations when switching languages.
    - Update `WeatherMapper` and `WeatherLocalDataSource` to support passing language parameters during save and retrieve operations.

- **UI and Refactoring**:
    - Add a TODO in `FavoriteDetailStatsGrid` for future unit conversion handling.
    - Clean up unused imports in `SkyPulseApp` and `WeatherDao`.