### PR TITLE
Implement "Clear Sky" weather alert type and refine alert matching logic ✔

### DIFF
--- a/app/src/main/java/com/iti/skypulse/core/notification/WeatherNotificationManager.kt
+++ b/app/src/main/java/com/iti/skypulse/core/notification/WeatherNotificationManager.kt
@@ -66,6 +66,10 @@ class WeatherNotificationManager(private val context: Context) {
             localizedContext.getString(R.string.alert_notification_title_high_wind),
             localizedContext.getString(R.string.alert_notification_message_high_wind)
         )
+        WeatherAlertType.CLEAR -> Pair(
+            localizedContext.getString(R.string.alert_notification_title_clear_match),
+            localizedContext.getString(R.string.alert_notification_message_clear_match)
+        )
     }
 
     private fun showNotification(id: String, title: String, message: String) {

--- a/app/src/main/java/com/iti/skypulse/data/model/alert/WeatherAlert.kt
+++ b/app/src/main/java/com/iti/skypulse/data/model/alert/WeatherAlert.kt
@@ -1,6 +1,6 @@
 package com.iti.skypulse.data.model.alert
 
-enum class WeatherAlertType { RAIN, SNOW, FOG, HIGH_TEMP, HIGH_WIND }
+enum class WeatherAlertType { RAIN, SNOW, FOG, HIGH_TEMP, HIGH_WIND, CLEAR }
 enum class AlertNotificationType { NOTIFICATION, ALARM }
 
 data class WeatherAlert(
@@ -14,21 +14,12 @@ data class WeatherAlert(
 )
 
 fun WeatherAlertType.matches(
-    conditionCode: Int,
-    tempCelsius: Double,
-    windSpeedMs: Double
+    conditionCode: Int, tempCelsius: Double, windSpeedMs: Double
 ): Boolean = when (this) {
-    WeatherAlertType.RAIN ->
-        conditionCode in 300..321 || conditionCode in 500..531
-    WeatherAlertType.SNOW ->
-        conditionCode in 600..622
-
-    WeatherAlertType.FOG ->
-        conditionCode in 700..781
-
-    WeatherAlertType.HIGH_TEMP ->
-        tempCelsius >= 40.0
-
-    WeatherAlertType.HIGH_WIND ->
-        windSpeedMs >= 10.0
+    WeatherAlertType.RAIN -> conditionCode in 200..232 || conditionCode in 300..321 || conditionCode in 500..531
+    WeatherAlertType.SNOW -> conditionCode in 600..622 || conditionCode == 511
+    WeatherAlertType.FOG -> conditionCode in 700..781
+    WeatherAlertType.HIGH_WIND -> windSpeedMs >= 10.0
+    WeatherAlertType.HIGH_TEMP -> tempCelsius >= 40.0
+    WeatherAlertType.CLEAR -> conditionCode == 800 || conditionCode == 801
 }

--- a/app/src/main/java/com/iti/skypulse/ui/alerts/components/AlertHelpers.kt
+++ b/app/src/main/java/com/iti/skypulse/ui/alerts/components/AlertHelpers.kt
@@ -8,6 +8,7 @@ import androidx.compose.material.icons.rounded.BeachAccess
 import androidx.compose.material.icons.rounded.BlurOn
 import androidx.compose.material.icons.rounded.Notifications
 import androidx.compose.material.icons.rounded.Thermostat
+import androidx.compose.material.icons.rounded.WbSunny
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
@@ -17,20 +18,22 @@ import com.iti.skypulse.data.model.alert.WeatherAlertType
 
 fun alertIcon(type: WeatherAlertType): ImageVector = when (type) {
     WeatherAlertType.HIGH_WIND -> Icons.Rounded.Air
-    WeatherAlertType.RAIN -> Icons.Rounded.BeachAccess
-    WeatherAlertType.SNOW -> Icons.Rounded.AcUnit
-    WeatherAlertType.FOG -> Icons.Rounded.BlurOn
+    WeatherAlertType.RAIN      -> Icons.Rounded.BeachAccess
+    WeatherAlertType.SNOW      -> Icons.Rounded.AcUnit
+    WeatherAlertType.FOG       -> Icons.Rounded.BlurOn
     WeatherAlertType.HIGH_TEMP -> Icons.Rounded.Thermostat
+    WeatherAlertType.CLEAR     -> Icons.Rounded.WbSunny
 }
 
 @Composable
 fun alertLabel(type: WeatherAlertType): String = stringResource(
     when (type) {
-        WeatherAlertType.RAIN -> R.string.alert_rain
-        WeatherAlertType.SNOW -> R.string.alert_snow
-        WeatherAlertType.FOG -> R.string.alert_fog
+        WeatherAlertType.RAIN      -> R.string.alert_rain
+        WeatherAlertType.SNOW      -> R.string.alert_snow
+        WeatherAlertType.FOG       -> R.string.alert_fog
         WeatherAlertType.HIGH_TEMP -> R.string.alert_high_temp
         WeatherAlertType.HIGH_WIND -> R.string.alert_high_wind
+        WeatherAlertType.CLEAR     -> R.string.alert_type_clear
     }
 )
 

--- a/app/src/main/res/values-ar-rEG/strings.xml
+++ b/app/src/main/res/values-ar-rEG/strings.xml
@@ -145,7 +145,9 @@
     <string name="alert_notification_title_fog">🌫️ تنبيه انخفاض الرؤية</string>
     <string name="alert_notification_title_high_temp">🌡️ تنبيه حرارة مرتفعة</string>
     <string name="alert_notification_title_high_wind">💨 تنبيه رياح قوية</string>
-
+    <string name="alert_type_clear">سماء صافية</string>
+    <string name="alert_notification_title_clear_match">☀️ تنبيه: سماء صافية</string>
+    <string name="alert_notification_message_clear_match">الجو صافٍ في الوقت المحدد. فرصة رائعة للخروج!</string>
     <string name="alert_notification_message_rain">من المتوقع هطول أمطار في الوقت الذي حددته. يُفضل حمل مظلة.</string>
     <string name="alert_notification_message_snow">من المتوقع تساقط الثلوج في الوقت الذي حددته. قد تكون الطرق زلقة.</string>
     <string name="alert_notification_message_fog">من المتوقع انخفاض في مستوى الرؤية. يُرجى القيادة بحذر إذا كنت ستخرج.</string>
@@ -164,5 +166,6 @@
     <string name="error_end_before_start">يجب أن يكون وقت الانتهاء بعد وقت البدء</string>
     <string name="error_alert_start_passed">انتهى وقت البدء. يرجى تعديل التنبيه وتحديد وقت جديد.</string>
     <string name="error_alert_expired">انتهت صلاحية هذا التنبيه. يرجى تعديله أو حذفه.</string>
+
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -159,5 +159,8 @@
     <string name="error_end_before_start">End time must be after start time</string>
     <string name="error_alert_start_passed">Start time has passed. Please edit the alert and set a new time.</string>
     <string name="error_alert_expired">This alert has expired. Please edit or delete it.</string>
+    <string name="alert_type_clear">Clear Sky</string>
+    <string name="alert_notification_title_clear_match">☀️ Clear Sky Alert</string>
+    <string name="alert_notification_message_clear_match">Skies are clear at your scheduled time. Great time to head out!</string>
 
 </resources>


### PR DESCRIPTION
- **Alerts Infrastructure**:
    - Add `CLEAR` to `WeatherAlertType` enum to support sunny/clear sky notifications.
    - Update `WeatherAlertType.matches` logic to include clear sky condition codes (800, 801).
    - Expand condition code ranges for `RAIN` (adding 2xx series) and `SNOW` (adding 511).
    - Map `WeatherAlertType.CLEAR` to notification titles and messages in `WeatherNotificationManager`.

- **UI and Resources**:
    - Assign `Icons.Rounded.WbSunny` and localized labels for the new `CLEAR` alert type in `AlertHelpers`.
    - Add string resources for "Clear Sky" alerts in both English and Arabic, including notification titles and descriptive messages.
    - Standardize code formatting in `AlertHelpers` and `WeatherAlert` for better readability.